### PR TITLE
Reset selection context after destroying selected entity

### DIFF
--- a/Engine-Editor/src/EditorLayer.cpp
+++ b/Engine-Editor/src/EditorLayer.cpp
@@ -85,8 +85,9 @@ namespace eg
 
 	void EditorLayer::OnUpdate(Timestep ts)
 	{
-
 		EG_PROFILE_FUNCTION();
+		if (!m_ActiveScene->GetRegistry().valid(m_HoveredEntity))
+			m_HoveredEntity = Entity({});
 		m_ActiveScene->OnViewportResize((uint32_t)m_ViewportSize.x, (uint32_t)m_ViewportSize.y);
 		if (FrameBufferSpecification spec = m_FrameBuffer->GetSpecification();
 			m_ViewportSize.x > 0.0f && m_ViewportSize.y > 0.0f &&

--- a/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
+++ b/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
@@ -67,7 +67,7 @@ namespace eg {
 					DrawEntityNode(entity);
 				});
 
-			if (ImGui::IsMouseDown(0) && ImGui::IsWindowHovered())
+			if (ImGui::IsMouseDown(0) && ImGui::IsWindowHovered() || !m_Context->GetRegistry().valid(m_SelectionContext))
 			{
 				m_SelectionContext = {};
 			}


### PR DESCRIPTION
Scene Selection context doesn't reset after destroying entity at runtime