### PR TITLE
Mono garbage collector destroys ScriptInstances which are in use

### DIFF
--- a/Engine/src/Engine/Scripting/ScriptEngine.cpp
+++ b/Engine/src/Engine/Scripting/ScriptEngine.cpp
@@ -478,6 +478,7 @@ namespace eg
 	MonoObject *ScriptEngine::InstantiateClass(MonoClass *monoClass)
 	{
 		MonoObject *object = mono_object_new(s_Data->AppDomain, monoClass);
+		
 		mono_runtime_object_init(object);
 		return object;
 	}
@@ -508,6 +509,7 @@ namespace eg
 		: m_ScriptClass(scriptClass)
 	{
 		m_Instance = m_ScriptClass->Instantiate();
+		m_InstanceHandle = mono_gchandle_new(m_Instance, true);
 
 		m_UUID = uuid;
 		m_EntityUUID = entity.GetUUID();
@@ -523,6 +525,11 @@ namespace eg
 			void *arg = &uuid;
 			m_ScriptClass->InvokeMethod(m_Instance, m_Constructor, &arg);
 		}
+	}
+
+	ScriptInstance::~ScriptInstance()
+	{
+		mono_gchandle_free(m_InstanceHandle);
 	}
 
 	MonoString* ScriptEngine::CreateString(const char* string)

--- a/Engine/src/Engine/Scripting/ScriptEngine.h
+++ b/Engine/src/Engine/Scripting/ScriptEngine.h
@@ -99,7 +99,7 @@ namespace eg {
 	{
 	public:
 		ScriptInstance(Ref<ScriptClass> scriptClass, Entity entity, UUID uuid);
-
+		~ScriptInstance();
 		void InvokeOnCreate();
 		void InvokeOnUpdate(float ts);
 		void InvokeOn2DCollisionEnter(InternalCollision2DEvent collision);
@@ -139,6 +139,7 @@ namespace eg {
 		UUID m_EntityUUID;
 		Ref<ScriptClass> m_ScriptClass;
 
+		uint32_t m_InstanceHandle = 0;
 		MonoObject* m_Instance = nullptr;
 		MonoMethod* m_Constructor = nullptr;
 		MonoMethod* m_OnCreateMethod = nullptr;


### PR DESCRIPTION
To solve the problem we create a mono handle for the instance and free the handle when the instance is destroyed.