### PR TITLE
Changed how animations are added to animator

### DIFF
--- a/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
+++ b/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
@@ -1457,12 +1457,22 @@ namespace eg
 		DrawComponent<AnimatorComponent>("Animator", entity, [entity, this](auto &component)
 										 {
 			bool ShowAnimationPreview = !(m_Context->IsRunning());
-				if (PrettyButton("Add Animation", true))
-				{
-					std::string name = "Animation" + std::to_string(component.Animator2D->GetAnimations()->size());
-					component.Animator2D->AddAnimationWithName(name);
-					Commands::ExecuteVectorCommand<Ref<Animation>>({ component.Animator2D->GetAnimations(), Commands::VectorCommandType::REMOVE_LAST, Commands::VectorCommandType::ADD, nullptr, Animation::Create() });
-				}
+				PrettyButton("Add Animation", true)
+                if (ImGui::BeginDragDropTarget()) {
+                    int64_t* uuid;
+
+                    if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("ContentBrowserPanel")) {
+                        uuid = (int64_t*)payload->Data;
+
+                        Ref<Animation> animation = Animation::Create((UUID)(*uuid));
+                        if (animation) {
+							component.Animator2D->AddAnimation(animation);
+                            Commands::ExecuteVectorCommand<Ref<Animation>>({ component.Animator2D->GetAnimations(), Commands::VectorCommandType::REMOVE_LAST, Commands::VectorCommandType::ADD, nullptr, animation });
+                        } else
+                            EG_WARN("Could not load animation from {0}", ResourceDatabase::GetResourcePath(*uuid));
+                    }
+                    ImGui::EndDragDropTarget();
+                }
 				const Ref<std::vector<Ref<Animation>>> animations = component.Animator2D->GetAnimations();
 				if (animations->size() > 0)
 				{


### PR DESCRIPTION
Now you add animations by dragging them onto the AddAnimation button. Not by clicking it setting the animation name and then dragging the animation to the animation button inside the animation.