### PR TITLE
oldTime variable wasn't reset when hitting play

### DIFF
--- a/Engine-Editor/src/EditorActions.cpp
+++ b/Engine-Editor/src/EditorActions.cpp
@@ -8,6 +8,8 @@ namespace eg
 
 	std::string EditorActions::ExecuteEntityAction(const std::string& actionName, const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
+
 		if (actionName == "GetUUID")
 		{
 			return GetUUID(params);
@@ -104,6 +106,8 @@ namespace eg
 
 	std::string EditorActions::ExecuteComponentAction(const std::string& actionName, const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
+
 		if (actionName == "GetTransformComponent")
 		{
 			return GetTransformComponent(params);
@@ -180,6 +184,8 @@ namespace eg
 
 	std::string EditorActions::GetUUID(const std::vector<std::string>& params)
 	{
+        EG_PROFILE_FUNCTION();
+
 		if (params.size() < 1)
 			return "No entity name provided.";
 
@@ -193,6 +199,8 @@ namespace eg
 
 	std::string EditorActions::Exists(const std::vector<std::string>& params)
 	{
+        EG_PROFILE_FUNCTION();
+
 		if (params.size() < 1)
 			return "No entity name provided.";
 
@@ -209,6 +217,8 @@ namespace eg
 
 	std::string EditorActions::GetAllEntities(const std::vector<std::string>& params)
 	{
+        EG_PROFILE_FUNCTION();
+
 		auto view = m_Scene->GetEntitiesWith<TransformComponent>();
 		std::string entities = "";
 		for (auto entity : view)
@@ -221,6 +231,8 @@ namespace eg
 
 	std::string EditorActions::ChangeName(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
+
 		if (params.size() < 1)
 			return "No entity name provided.";
 		else if (params.size() < 2)
@@ -248,6 +260,8 @@ namespace eg
 
 	std::string EditorActions::CreateEntity(const std::vector<std::string>& params)
 	{
+        EG_PROFILE_FUNCTION();
+
 		if (params.size() < 1)
 			return "No entity name provided.";
 
@@ -263,6 +277,7 @@ namespace eg
 
 	std::string EditorActions::DeleteEntity(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 
@@ -281,6 +296,7 @@ namespace eg
 
 	std::string EditorActions::GetAnyChildren(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 
@@ -303,6 +319,7 @@ namespace eg
 
 	std::string EditorActions::GetChildren(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 
@@ -325,6 +342,7 @@ namespace eg
 
 	std::string EditorActions::GetParent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 
@@ -346,6 +364,7 @@ namespace eg
 
 	std::string EditorActions::SetParent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -381,6 +400,7 @@ namespace eg
 
 	std::string EditorActions::IsChild(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No child entity UUID provided.";
 		else if (params.size() < 2)
@@ -410,6 +430,7 @@ namespace eg
 
 	std::string EditorActions::IsChildOfAny(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No child entity UUID provided.";
 		else if (params.size() < 2)
@@ -439,6 +460,7 @@ namespace eg
 
 	std::string EditorActions::AddComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -460,6 +482,7 @@ namespace eg
 
 	std::string EditorActions::RemoveComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -481,6 +504,7 @@ namespace eg
 
 	std::string EditorActions::HasComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -502,6 +526,7 @@ namespace eg
 
 	std::string EditorActions::InheritComponentInChildren(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -523,6 +548,7 @@ namespace eg
 
 	std::string EditorActions::InheritComponentFromParent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -544,6 +570,7 @@ namespace eg
 
 	std::string EditorActions::CopyComponentToChildren(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -565,6 +592,7 @@ namespace eg
 
 	std::string EditorActions::CopyComponentValuesToChildren(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -586,6 +614,7 @@ namespace eg
 
 	std::string EditorActions::CopyComponentWithValuesToChildren(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -607,6 +636,7 @@ namespace eg
 
 	std::string EditorActions::IsInheritedFromParent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -628,6 +658,7 @@ namespace eg
 
 	std::string EditorActions::IsInheritedInChildren(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -654,6 +685,7 @@ namespace eg
 
 	std::string EditorActions::GetTransformComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 
@@ -686,6 +718,7 @@ namespace eg
 
 	std::string EditorActions::SetTransformComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -750,6 +783,7 @@ namespace eg
 
 	std::string EditorActions::GetCameraComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 
@@ -782,6 +816,7 @@ namespace eg
 
 	std::string EditorActions::SetCameraComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -960,6 +995,7 @@ namespace eg
 
 	std::string EditorActions::GetSpriteRendererComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 
@@ -990,6 +1026,7 @@ namespace eg
 
 	std::string EditorActions::SetSpriteRendererComponent(const std::vector<std::string>& params)
 	{
+        EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -1086,6 +1123,7 @@ namespace eg
 
 	std::string EditorActions::GetCircleRendererComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 
@@ -1115,6 +1153,7 @@ namespace eg
 
 	std::string EditorActions::SetCircleRendererComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -1206,6 +1245,7 @@ namespace eg
 
 	std::string EditorActions::GetRigidBody2DComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 
@@ -1231,6 +1271,7 @@ namespace eg
 
 	std::string EditorActions::SetRigidBody2DComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -1309,6 +1350,7 @@ namespace eg
 
 	std::string EditorActions::GetBoxCollider2DComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 
@@ -1340,6 +1382,7 @@ namespace eg
 
 	std::string EditorActions::SetBoxCollider2DComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -1446,6 +1489,7 @@ namespace eg
 
 	std::string EditorActions::GetCircleCollider2DComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 
@@ -1476,6 +1520,7 @@ namespace eg
 
 	std::string EditorActions::SetCircleCollider2DComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)
@@ -1574,6 +1619,7 @@ namespace eg
 
 	std::string EditorActions::GetTextComponent(const std::vector<std::string>& params)
 	{
+        EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 
@@ -1604,6 +1650,7 @@ namespace eg
 
 	std::string EditorActions::SetTextComponent(const std::vector<std::string>& params)
 	{
+		EG_PROFILE_FUNCTION();
 		if (params.size() < 1)
 			return "No entity UUID provided.";
 		else if (params.size() < 2)

--- a/Engine-Editor/src/EditorApp.cpp
+++ b/Engine-Editor/src/EditorApp.cpp
@@ -6,6 +6,8 @@
 namespace eg {
 	bool Editor::OnWindowClose(WindowCloseEvent& e)
 	{
+		EG_PROFILE_FUNCTION();
+
 		if (IsProjectSaved())
 		{
 			SetRunning(false);
@@ -17,6 +19,8 @@ namespace eg {
 	}
 
 	Application* CreateApplication(ApplicationCommandLineArgs args) {
+		EG_PROFILE_FUNCTION();
+
 		ApplicationSpecification spec;
 		spec.Name = "Editor";
 		spec.CommandLineArgs = args;

--- a/Engine-Editor/src/EditorLayer.cpp
+++ b/Engine-Editor/src/EditorLayer.cpp
@@ -31,6 +31,7 @@ namespace eg
 	EditorLayer::EditorLayer()
 		: Layer("Sandbox2D"), m_Camera(1280.0f / 720.0f, true)
 	{
+        EG_PROFILE_FUNCTION();
 		m_RecentProjectSerializer = RecentProjectSerializer();
 		m_WelcomePanel = CreateScope<WelcomingPanel>(m_RecentProjectSerializer.getProjectList(), m_RecentProjectSerializer);
 		m_NameNewProjectPanel = CreateScope<NameNewProjectPanel>();
@@ -41,6 +42,8 @@ namespace eg
 
 	void EditorLayer::OnAttach()
 	{
+        EG_PROFILE_FUNCTION();
+
 		ImGuiIO& io = ImGui::GetIO();
 
 		ImFontConfig font_config;
@@ -73,7 +76,6 @@ namespace eg
 
 		m_WelcomePanel->InitWelcomingPanel();
 
-		EG_PROFILE_FUNCTION();
 
 		m_IconPlay = IconLoader::GetIcon(Icons::Editor_PlayButton);
 		m_IconPause = IconLoader::GetIcon(Icons::Editor_PauseButton);
@@ -101,12 +103,11 @@ namespace eg
 
 	void EditorLayer::OnUpdate(Timestep ts)
 	{
+		EG_PROFILE_FUNCTION();
 		if (m_WelcomePanel->IsShown()) {
 			return;
 		}
-
-
-		EG_PROFILE_FUNCTION();
+		
 		if (!m_ActiveScene->GetRegistry().valid(m_HoveredEntity))
 			m_HoveredEntity = Entity({});
 		m_ActiveScene->OnViewportResize((uint32_t)m_ViewportSize.x, (uint32_t)m_ViewportSize.y);
@@ -198,6 +199,7 @@ namespace eg
 
 	void EditorLayer::OnImGuiRender()
 	{
+        EG_PROFILE_FUNCTION();
 		static bool dockspaceOpen = true;
 		static bool opt_fullscreen_persistant = true;
 		bool opt_fullscreen = opt_fullscreen_persistant;
@@ -489,6 +491,7 @@ namespace eg
 
 	void EditorLayer::UI_Toolbar()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{ 0.0f, 2.0f });
 		ImGui::PushStyleVar(ImGuiStyleVar_ItemInnerSpacing, ImVec2{ 0.0f, 0.0f });
 		ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{ 0.0f, 0.0f, 0.0f, 0.0f });
@@ -592,6 +595,7 @@ namespace eg
 
 	void EditorLayer::OnEvent(Event& e)
 	{
+		EG_PROFILE_FUNCTION();
 		m_Camera.OnEvent(e);
 		m_EditorCamera.OnEvent(e);
 
@@ -602,6 +606,7 @@ namespace eg
 
 	bool EditorLayer::OnKeyPressed(KeyPressedEvent& e)
 	{
+		EG_PROFILE_FUNCTION();
 		if (e.IsRepeat())
 			return false;
 
@@ -715,6 +720,7 @@ namespace eg
 
 	bool EditorLayer::OnMouseButtonPressed(MouseButtonPressedEvent& e)
 	{
+		EG_PROFILE_FUNCTION();
 		if (e.GetMouseButton() == (int)Mouse::ButtonLeft)
 		{
 			if (m_ViewportHovered && !ImGuizmo::IsOver() && !Input::IsKeyPressed(KeyCode::LeftAlt))
@@ -725,7 +731,7 @@ namespace eg
 
 	void EditorLayer::OnOverlayRender()
 	{
-
+		EG_PROFILE_FUNCTION();
 		if (m_SceneState == SceneState::Play)
 		{
 			Entity cameraEntity = m_ActiveScene->GetPrimaryCameraEntity();
@@ -810,6 +816,7 @@ namespace eg
 
 	void EditorLayer::NewScene()
 	{
+		EG_PROFILE_FUNCTION();
 		m_ActiveScene = CreateRef<Scene>();
 		m_RuntimeScene = m_ActiveScene;
 
@@ -823,6 +830,7 @@ namespace eg
 
 	void EditorLayer::OpenScene()
 	{
+		EG_PROFILE_FUNCTION();
 		std::string filepath = FileDialogs::OpenFile("Muniffic Scene (*.egscene)\0*.egscene\0");
 		if (!filepath.empty())
 		{
@@ -836,6 +844,7 @@ namespace eg
 
 	void EditorLayer::OpenScene(const std::filesystem::path& path)
 	{
+		EG_PROFILE_FUNCTION();
 		if (m_SceneState != SceneState::Edit)
 			OnSceneStop();
 
@@ -859,6 +868,7 @@ namespace eg
 
 	void EditorLayer::SaveAs()
 	{
+		EG_PROFILE_FUNCTION();
 		std::string filepath = FileDialogs::SaveFile("Muniffic Scene (*.egscene)\0*.egscene\0");
 		if (!filepath.empty())
 		{
@@ -876,6 +886,7 @@ namespace eg
 
 	void EditorLayer::Save()
 	{
+		EG_PROFILE_FUNCTION();
 		if (m_ActiveScenePath.empty())
 			SaveAs();
 		else
@@ -889,6 +900,7 @@ namespace eg
 
 	bool EditorLayer::CreateCmakelists(const std::filesystem::path path)
 	{
+		EG_PROFILE_FUNCTION();
 		std::filesystem::path pathToScripts(path.string() + "\\Assets\\Scripts");
 		m_CustomScriptsDirectory = pathToScripts;
 		std::filesystem::path cmakeFilePath = pathToScripts / "CMakeLists.txt";
@@ -915,6 +927,7 @@ namespace eg
 
 	const std::string EditorLayer::CompileCustomScripts()
 	{
+		EG_PROFILE_FUNCTION();
 		std::filesystem::path projectDirectory =  m_CurrentProject->GetProjectDirectory() / "Assets" / "Scripts";
 		const std::string& projectName = m_CurrentProject->GetProjectName();
 		std::string command = "cd " + projectDirectory.string() + " && cmake -DPROJECT_NAME=" + projectName + " . && cmake --build .";
@@ -927,6 +940,7 @@ namespace eg
 
 	void EditorLayer::NewProject()
 	{
+		EG_PROFILE_FUNCTION();
 		std::filesystem::path saveDir = std::filesystem::current_path() / "Projects" / m_NameNewProjectPanel->projectName / (m_NameNewProjectPanel->projectName + ".mnproj");
 		std::filesystem::path absolutePath = std::filesystem::absolute(saveDir);
 		//std::filesystem::path savePath = absolutePath / "Projects";
@@ -975,6 +989,7 @@ namespace eg
 
 	bool EditorLayer::OpenProject()
 	{
+		EG_PROFILE_FUNCTION();
 		std::string filepath = FileDialogs::OpenFile("Muniffic Project (*.mnproj)\0*.mnproj\0");
 		if (filepath.empty())
 		{
@@ -989,6 +1004,7 @@ namespace eg
 
 	void EditorLayer::OpenProject(const std::filesystem::path& path)
 	{
+        EG_PROFILE_FUNCTION();
 		if (m_CurrentProject = Project::Load(path))
 		{
 			ScriptEngine::Init();
@@ -1014,16 +1030,19 @@ namespace eg
 
 	void EditorLayer::SaveProjectAs()
 	{
+        EG_PROFILE_FUNCTION();
 		ConsolePanel::Log("File: EditorLayer.cpp - Project saved", ConsolePanel::LogType::Info);
 	}
 
 	void EditorLayer::SaveProject()
 	{
+        EG_PROFILE_FUNCTION();
 		ConsolePanel::Log("File: EditorLayer.cpp - Project saved", ConsolePanel::LogType::Info);
 	}
 
 	void EditorLayer::SerializeScene(Ref<Scene> scene, const std::filesystem::path& path)
 	{
+        EG_PROFILE_FUNCTION();
 		SceneSerializer serializer(scene);
 		serializer.Serialize(path.string());
 		ConsolePanel::Log("File: EditorLayer.cpp - Scene serialized", ConsolePanel::LogType::Info);
@@ -1031,28 +1050,36 @@ namespace eg
 
 	void EditorLayer::OnScenePlay()
 	{
-		if (m_ActiveScene->GetEntitiesWith<CameraComponent>().empty())
+		EG_PROFILE_FUNCTION();
 		{
-			ImGui::OpenPopup("No Camera");
-
-			return;
+			EG_PROFILE_SCOPE("Check Camera");
+		    if (m_ActiveScene->GetEntitiesWith<CameraComponent>().empty())
+		    {
+		    	ImGui::OpenPopup("No Camera");
+		    
+		    	return;
+		    }
 		}
-
-		if (!m_RuntimeScene)
-			m_RuntimeScene = CreateRef<Scene>();
 		if (m_SceneState == SceneState::Simulate)
 			OnSceneStop();
 		m_SceneState = SceneState::Play;
-
-		m_RuntimeScene = Scene::Copy(m_ActiveScene);
-		m_RuntimeScene->OnRuntimeStart();
-		m_ActiveScene = m_RuntimeScene;
-		m_SceneHierarchyPanel.SetContext(m_ActiveScene);
-		ConsolePanel::Log("File: EditorLayer.cpp - Scene started", ConsolePanel::LogType::Info);
+		{
+            EG_PROFILE_SCOPE("Copying Scene");
+		    m_RuntimeScene = Scene::Copy(m_ActiveScene);
+		}
+		{
+            EG_PROFILE_SCOPE("OnRuntimeStart");
+			oldTime = std::chrono::high_resolution_clock::now();
+		    m_RuntimeScene->OnRuntimeStart();
+		    m_ActiveScene = m_RuntimeScene;
+		    m_SceneHierarchyPanel.SetContext(m_ActiveScene);
+		    ConsolePanel::Log("File: EditorLayer.cpp - Scene started", ConsolePanel::LogType::Info);
+		}
 	}
 
 	void EditorLayer::OnSceneSimulate()
 	{
+		EG_PROFILE_FUNCTION();
 		if (m_SceneState == SceneState::Play)
 			OnSceneStop();
 
@@ -1067,6 +1094,8 @@ namespace eg
 
 	void EditorLayer::OnScenePause()
 	{
+		EG_PROFILE_FUNCTION();
+
 		if (m_SceneState == SceneState::Edit)
 			return;
 		ConsolePanel::Log("File: EditorLayer.cpp - Scene paused", ConsolePanel::LogType::Info);
@@ -1075,7 +1104,9 @@ namespace eg
 
 	void EditorLayer::OnSceneStop()
 	{
+        EG_PROFILE_FUNCTION();
 		EG_CORE_ASSERT(m_SceneState == SceneState::Play || m_SceneState == SceneState::Simulate);
+		
 
 		if (m_SceneState == SceneState::Play)
 			m_ActiveScene->OnRuntimeStop();
@@ -1092,6 +1123,8 @@ namespace eg
 
 	void EditorLayer::OnDuplicateEntity()
 	{
+		EG_PROFILE_FUNCTION();
+
 		if (m_SceneState == SceneState::Play) {
 			ConsolePanel::Log("File: EditorLayer.cpp - Cannot duplicate entities while playing", ConsolePanel::LogType::Warning);
 			return;
@@ -1110,6 +1143,7 @@ namespace eg
 
 	void EditorLayer::CloseAddResourcePanel()
 	{
+		EG_PROFILE_FUNCTION();
 		m_AddResourcePanel = nullptr;
 	}
 }

--- a/Engine-Editor/src/EditorLayer.cpp
+++ b/Engine-Editor/src/EditorLayer.cpp
@@ -161,7 +161,7 @@ namespace eg
 		{
 			// Update
 
-			m_RuntimeScene->OnUpdateRuntime(ts, oldTime);
+			m_RuntimeScene->OnUpdateRuntime(ts, m_OldTime);
 
 			// Render
 			// Renderer2D::BeginScene(m_EditorCamera);
@@ -1069,7 +1069,7 @@ namespace eg
 		}
 		{
             EG_PROFILE_SCOPE("OnRuntimeStart");
-			oldTime = std::chrono::high_resolution_clock::now();
+			m_OldTime = std::chrono::high_resolution_clock::now();
 		    m_RuntimeScene->OnRuntimeStart();
 		    m_ActiveScene = m_RuntimeScene;
 		    m_SceneHierarchyPanel.SetContext(m_ActiveScene);

--- a/Engine-Editor/src/EditorLayer.h
+++ b/Engine-Editor/src/EditorLayer.h
@@ -138,7 +138,7 @@ namespace eg
 		ImFont* m_PoppinsMediumFont;
 
 		//Time for fixedUpdate loop
-		std::chrono::steady_clock::time_point oldTime = std::chrono::high_resolution_clock::now();;
+		std::chrono::steady_clock::time_point m_OldTime = std::chrono::high_resolution_clock::now();;
 		// Panels
 		SceneHierarchyPanel m_SceneHierarchyPanel;
 		Ref<ContentBrowserPanel> m_ContentBrowserPanel = nullptr;

--- a/Engine-Editor/src/IconLoader.cpp
+++ b/Engine-Editor/src/IconLoader.cpp
@@ -9,6 +9,8 @@ namespace eg
 
 	Ref<Texture2D> IconLoader::GetIcon(Icons icon)
 	{
+		EG_PROFILE_FUNCTION();
+
 		if(m_Icons.find(icon) == m_Icons.end())
 		{
 			EG_WARN("Icon {0} not found", static_cast<int>(icon));
@@ -19,6 +21,8 @@ namespace eg
 
 	void IconLoader::LoadIcons()
 	{
+		EG_PROFILE_FUNCTION();
+
 		Ref<Texture2D> defaultIcon = Texture2D::Create(m_DefaultIconPath.string());
 
 		if (defaultIcon == nullptr || !defaultIcon->IsLoaded())
@@ -52,6 +56,8 @@ namespace eg
 
 	std::filesystem::path IconLoader::GetIconPath(Icons icon)
 	{
+		EG_PROFILE_FUNCTION();
+
 		std::filesystem::path basePath = "resources/icons/";
 		std::filesystem::path editorPath = basePath / "editor/";
 		std::filesystem::path welcomePanelPath = basePath / "welcome_panel/";

--- a/Engine-Editor/src/Panels/AddResourcePanel.cpp
+++ b/Engine-Editor/src/Panels/AddResourcePanel.cpp
@@ -19,12 +19,14 @@ namespace eg
 	static float textY = 0;
 	AddResourcePanel::AddResourcePanel()
 	{
+        EG_PROFILE_FUNCTION();
 		m_ImagePanel = CreateRef<ImagePanel>();
 		m_AnimationPanel = CreateRef<AnimationPanel>();
 		m_ImagePanelinitialized = m_ImagePanel->InitImagePanel();
 		m_AnimationPanelinitialized = m_AnimationPanel->InitAnimationPanel();
 		LoadIcons();
 	}
+
 	void AddResourcePanel::OnImGuiRender()
 	{
 		if (!m_showResourcePanel)
@@ -118,12 +120,14 @@ namespace eg
 
 	void AddResourcePanel::Update(float ts)
 	{
+        EG_PROFILE_FUNCTION();
 		if(m_AnimationPanel->IsAnimationPanelOpen())
 			m_AnimationPanel->OnUpdate(ts);
 	}
 
 	bool AddResourcePanel::ChooseNewResource(const std::string filter)
 	{
+        EG_PROFILE_FUNCTION();
 		std::filesystem::path path = FileDialogs::OpenFile(filter.c_str());
 		if (path.empty())
 		{
@@ -135,6 +139,7 @@ namespace eg
 
 	bool AddResourcePanel::ButtonCenteredOnLine(const char* label, int width, int height,bool isDown, float alignment)
 	{
+        EG_PROFILE_FUNCTION();
 		ImGuiStyle& style = ImGui::GetStyle();
 
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 10.f);
@@ -163,6 +168,7 @@ namespace eg
 	}
 
 	void AddResourcePanel::TextCenteredOnLine(const char* label, float alignment) {
+        EG_PROFILE_FUNCTION();
 		ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 40));
 		float oldSize = ImGui::GetFont()->Scale;
 		//ImGui::GetFont()->Scale *= 2;
@@ -176,10 +182,11 @@ namespace eg
 		//ImGui::GetFont()->Scale = oldSize;
 		ImGui::PopFont();;
 		ImGui::PopStyleVar();
-		
+
 	}
 
 	bool AddResourcePanel::PositionButtonWithTheSameWidth(const char* label, int numberOfButtonsInLine, int index, int width, int height) {
+        EG_PROFILE_FUNCTION();
 		if (index <= numberOfButtonsInLine) {
 			ImGuiStyle& style = ImGui::GetStyle();
 			const float thumbnailSize = 128.0f;
@@ -211,6 +218,7 @@ namespace eg
 	}
 
 	void AddResourcePanel::DrawCenteredText(const std::string& label, const float& cellSize, const float& cursorX, const int& btnIndex) {
+        EG_PROFILE_FUNCTION();
 		auto textWidth = ImGui::CalcTextSize(label.c_str()).x;
 		//auto CursorX = ImGui::GetCursorPosX();
 		float offset = (cellSize - textWidth) * 0.48f;
@@ -222,6 +230,7 @@ namespace eg
 	}
 
 	bool AddResourcePanel::RenderFile(const std::string& label, const float& thumbnailSize) {
+        EG_PROFILE_FUNCTION();
 		//static float thumbnailSize = 128.0f;
 
 		ImGui::PushID(label.c_str());
@@ -245,12 +254,13 @@ namespace eg
 		else if (label._Equal("Custom"))
 			openPopup = ImGui::ImageButton((ImTextureID)m_CustomIcon->GetRendererID(), { thumbnailSize, thumbnailSize });
 		ImGui::PopStyleColor();
-		ImGui::PopID(); 
+		ImGui::PopID();
 
 		return openPopup;
 	}
 
 	void AddResourcePanel::LoadIcons() {
+        EG_PROFILE_FUNCTION();
 		m_AnimationIcon = IconLoader::GetIcon(Icons::AddResource_Animation);
 		m_ShaderIcon = IconLoader::GetIcon(Icons::AddResource_Shader);
 		m_FontIcon = IconLoader::GetIcon(Icons::AddResource_Font);
@@ -260,5 +270,5 @@ namespace eg
 		m_NativeScriptIcon = IconLoader::GetIcon(Icons::AddResource_NativeScript);
 		m_CustomIcon = IconLoader::GetIcon(Icons::AddResource_Custom);
 	}
-	
+
 }

--- a/Engine-Editor/src/Panels/AssistantPanel.cpp
+++ b/Engine-Editor/src/Panels/AssistantPanel.cpp
@@ -25,6 +25,7 @@ namespace eg
 		m_shouldListen(false),
 		m_assistantInitialized(false)
 	{
+        EG_PROFILE_FUNCTION();
 		memset(buffer, 0, sizeof(buffer));
 
 		mdConfig = ImGui::MarkdownConfig();
@@ -55,6 +56,7 @@ namespace eg
 
 	std::string AssistantPanel::LoadInstructions()
 	{
+        EG_PROFILE_FUNCTION();
 		std::string filename = "resources/assistant/instructions.txt";
 
 		std::ifstream file(filename);
@@ -70,6 +72,7 @@ namespace eg
 
 	void AssistantPanel::DoMessage(const std::string& message)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assistantManager->GetVoiceAssistantListening())
 		{
 			assistantManager->SetVoiceAssistantListening(false);
@@ -83,6 +86,7 @@ namespace eg
 
 	void AssistantPanel::RenderUserMessage(const std::string& message)
 	{
+        EG_PROFILE_FUNCTION();
 		float padding = 10.0f;
 		float rightMargin = 15.0f;
 		float maxBubbleWidth = ImGui::GetWindowSize().x * 0.6f;
@@ -117,6 +121,7 @@ namespace eg
 
 	std::string AssistantPanel::GetLanguageSymbol(const std::string& language)
 	{
+        EG_PROFILE_FUNCTION();
 		static const std::unordered_map<std::string, std::string> languageMap = {
 			{"csharp", "C#"}, {"cpp", "C++"}, {"python", "Python"},
 			{"javascript", "JavaScript"}, {"java", "Java"}, {"ruby", "Ruby"},
@@ -137,6 +142,7 @@ namespace eg
 	}
 
 	std::string AssistantPanel::ExtractLanguageName(std::string line) {
+        EG_PROFILE_FUNCTION();
 		if(line.find("```") == std::string::npos)
 			return "";
 
@@ -145,6 +151,7 @@ namespace eg
 	}
 
 	bool AssistantPanel::StartsOrEndsCodeBlock(std::string line) {
+        EG_PROFILE_FUNCTION();
 		if (line.find("```") != std::string::npos)
 		{
 			line.erase(std::remove_if(line.begin(), line.end(), ::isspace), line.end());
@@ -156,6 +163,7 @@ namespace eg
 
 	void AssistantPanel::RenderAssistantMessage(const std::string& message, int id)
 	{
+        EG_PROFILE_FUNCTION();
 		ImDrawList* drawList = ImGui::GetWindowDrawList();
 		drawList->ChannelsSplit(3);
 		drawList->ChannelsSetCurrent(2);
@@ -283,7 +291,7 @@ namespace eg
 		}
 
 		drawList->ChannelsSetCurrent(0);
-	
+
 		ImGui::GetWindowDrawList()->AddRectFilled(
 			initialCursorPos,
 			ImVec2(ImGui::GetCursorScreenPos().x + bubbleWidth, ImGui::GetCursorScreenPos().y + padding),
@@ -305,6 +313,7 @@ namespace eg
 
 	void AssistantPanel::OnImGuiRender()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::Begin("Assistant Panel");
 
 		if (!m_assistantInitialized)
@@ -511,6 +520,7 @@ namespace eg
 
 	void AssistantPanel::UpdateAssistantStatus()
 	{
+        EG_PROFILE_FUNCTION();
 		if (assistantManager->IsNewVoiceMessageAvailable())
 		{
 			std::string message = assistantManager->GetLastVoiceMessage();
@@ -540,6 +550,7 @@ namespace eg
 
 	void AssistantPanel::RenderAssistantSettings()
 	{
+        EG_PROFILE_FUNCTION();
 		if (ImGui::BeginPopupModal("Assistant Settings", NULL, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_AlwaysAutoResize))
 		{
 			ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.14f, 0.12f, 0.22f, 1.0f));
@@ -605,6 +616,7 @@ namespace eg
 
 	void AssistantPanel::RunMessage(const std::string& message)
 	{
+        EG_PROFILE_FUNCTION();
 		if (message.empty() || m_isLastMessageFromUser)
 			return;
 

--- a/Engine-Editor/src/Panels/ConsolePanel.cpp
+++ b/Engine-Editor/src/Panels/ConsolePanel.cpp
@@ -2,7 +2,7 @@
 
 namespace eg {
 	ConsolePanel::ConsolePanel() {
-
+        EG_PROFILE_FUNCTION();
     };
     std::vector<ConsolePanel::LogMessage*> ConsolePanel::Logs;
     enum class LogType {
@@ -11,6 +11,7 @@ namespace eg {
         Error
     };
     void ConsolePanel::ClearLogs() {
+        EG_PROFILE_FUNCTION();
         Logs.clear();
     };
     std::string ConsolePanel::getCurrentTime() {
@@ -21,6 +22,7 @@ namespace eg {
         return time;
     }
     void ConsolePanel::Draw() {
+        EG_PROFILE_FUNCTION();
         for (auto& log : Logs) {
             switch (log->logType) {
             case LogType::Info:
@@ -48,17 +50,21 @@ namespace eg {
         }
         //ConsolePanel::ClearLogs();
     };
+
     void ConsolePanel::Log(const std::string& message, LogType type) {
+        EG_PROFILE_FUNCTION();
         std::string mess = ConsolePanel::getCurrentTime() + " | " + message;
         Logs.push_back(new ConsolePanel::LogMessage(mess, type));
     }
+
     void ConsolePanel::OnImGuiRender() {
+        EG_PROFILE_FUNCTION();
         ImGui::Begin("Console");
         this->Draw();
-        ImGui::End();  
+        ImGui::End();
     };
 
-    
-    
-	
+
+
+
 }

--- a/Engine-Editor/src/Panels/ContentBrowserPanel.cpp
+++ b/Engine-Editor/src/Panels/ContentBrowserPanel.cpp
@@ -16,6 +16,7 @@ namespace eg
 	ContentBrowserPanel::ContentBrowserPanel()
 	: m_BaseDirectory(AssetDirectoryManager::getRootDirectoryUUID()), m_CurrentDirectory(m_BaseDirectory)
 	{
+        EG_PROFILE_FUNCTION();
 		m_DirectoryIcon = IconLoader::GetIcon(Icons::ContentBrowser_Directory);
 		m_FileIcon = IconLoader::GetIcon(Icons::ContentBrowser_File);
 		ResourceDatabase::SetCurrentDirectoryUUID(m_CurrentDirectory);
@@ -23,11 +24,13 @@ namespace eg
 
 	void ContentBrowserPanel::Update(float ts)
 	{
+        EG_PROFILE_FUNCTION();
 		if(m_AnimationEditorPanel && m_AnimationEditorPanel->IsAnimationEditorOpen())
 			m_AnimationEditorPanel->Update(ts);
 	}
 
 	void ContentBrowserPanel::DrawCenteredText(const std::string& text, const float& cellSize) {
+        EG_PROFILE_FUNCTION();
 		auto textWidth = ImGui::CalcTextSize(text.c_str()).x;
 		auto CursorX = ImGui::GetCursorPosX();
 		float offset = (cellSize - textWidth) * 0.43f;
@@ -71,6 +74,8 @@ namespace eg
 
 	void ContentBrowserPanel::InitPanels()
 	{
+        EG_PROFILE_FUNCTION();
+        EG_PROFILE_FUNCTION();
 		m_DeleteFilePanel = CreateScope<DeleteFilePanel>();
 		m_RenameFolderPanel = CreateScope<RenameFolderPanel>();
 		m_DeleteDirectoryPanel = CreateScope<DeleteDirectoryPanel>();
@@ -80,6 +85,8 @@ namespace eg
 
 	void ContentBrowserPanel::RenderFile(UUID key, const std::string& name, ResourceType type)
 	{
+        EG_PROFILE_FUNCTION();
+        EG_PROFILE_FUNCTION();
 		static float thumbnailSize = 128.0f;
 
 		ImGui::PushID(name.c_str());
@@ -116,7 +123,7 @@ namespace eg
 				ImGui::EndPopup();
 				ImGui::PopStyleColor();
 				ImGui::PopID();
-				
+
 				return;
 			}
 			if (animData && animData->Type == ResourceType::Animation) {
@@ -135,6 +142,7 @@ namespace eg
 	}
 
 	void ContentBrowserPanel::OnImGuiRender() {
+        EG_PROFILE_FUNCTION();
 			if (m_DeleteFilePanel->IsShown())
 			m_DeleteFilePanel->OnImGuiRender();
 

--- a/Engine-Editor/src/Panels/CreateDirectoryPanel.cpp
+++ b/Engine-Editor/src/Panels/CreateDirectoryPanel.cpp
@@ -5,16 +5,20 @@ namespace eg
 {
 	CreateDirectoryPanel::CreateDirectoryPanel()
 		: m_Show(false), m_DirectoryUUID(0)
-	{ }
+	{
+        EG_PROFILE_FUNCTION();
+    }
 
 	void CreateDirectoryPanel::ShowWindow(UUID parentUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		m_Show = true;
 		m_DirectoryUUID = parentUUID;
 	}
 
 	void CreateDirectoryPanel::OnImGuiRender()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::SetNextWindowPos(ImVec2(Application::Get().GetWindow().GetWidth() / 2, Application::Get().GetWindow().GetHeight() / 2));
 
 		ImGui::Begin("Create directory?", &m_Show, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize);

--- a/Engine-Editor/src/Panels/DeleteDirectoryPanel.cpp
+++ b/Engine-Editor/src/Panels/DeleteDirectoryPanel.cpp
@@ -5,16 +5,20 @@ namespace eg
 {
 	DeleteDirectoryPanel::DeleteDirectoryPanel()
 	: m_Show(false), m_DirectoryUUID(0)
-	{ }
+	{
+        EG_PROFILE_FUNCTION();
+    }
 
 	void DeleteDirectoryPanel::ShowWindow(UUID directoryUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		m_Show = true;
 		m_DirectoryUUID = directoryUUID;
 	}
 
 	void DeleteDirectoryPanel::OnImGuiRender()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::SetNextWindowPos(ImVec2(Application::Get().GetWindow().GetWidth() / 2, Application::Get().GetWindow().GetHeight() / 2));
 
 		ImGui::Begin("Delete directory?", &m_Show, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize);

--- a/Engine-Editor/src/Panels/DeleteFilePanel.cpp
+++ b/Engine-Editor/src/Panels/DeleteFilePanel.cpp
@@ -4,10 +4,13 @@ namespace eg
 {
 	DeleteFilePanel::DeleteFilePanel()
 		: m_Show(false), m_UUID(0), m_Type(ResourceType::None)
-	{ }
+	{
+        EG_PROFILE_FUNCTION();
+    }
 
 	void DeleteFilePanel::ShowWindow(UUID uuid, ResourceType type)
 	{
+        EG_PROFILE_FUNCTION();
 		m_Show = true;
 		m_UUID = uuid;
 		m_Type = type;
@@ -15,6 +18,7 @@ namespace eg
 
 	void DeleteFilePanel::OnImGuiRender()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::SetNextWindowPos(ImVec2(Application::Get().GetWindow().GetWidth() / 2, Application::Get().GetWindow().GetHeight() / 2));
 
 		ImGui::Begin("Delete file?", &m_Show, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize);

--- a/Engine-Editor/src/Panels/NameNewProjectPanel.cpp
+++ b/Engine-Editor/src/Panels/NameNewProjectPanel.cpp
@@ -7,15 +7,19 @@ namespace eg
 {
 	NameNewProjectPanel::NameNewProjectPanel()
 		: m_Show(false), m_ProjectUUID(0)
-	{ }
+	{
+	    EG_PROFILE_FUNCTION();
+	}
 
 	void NameNewProjectPanel::ShowWindow(UUID directoryUUID)
 	{
+		EG_PROFILE_FUNCTION();
 		m_ProjectUUID = directoryUUID;
 		m_Show = true;
 	}
 
 	char correctChar(char& s) {
+        EG_PROFILE_FUNCTION();
 		if (s == ' ') {
 			return '_';
 		}
@@ -24,6 +28,7 @@ namespace eg
 
 	bool NameNewProjectPanel::isNameAllowed(char* name)
 	{
+        EG_PROFILE_FUNCTION();
 		while (*name != '\0') {
 			if (correctChar(*name) != *name)
 			{
@@ -36,6 +41,7 @@ namespace eg
 
 	std::vector<char> NameNewProjectPanel::makeNameAllowed(char* name)
 	{
+        EG_PROFILE_FUNCTION();
 		std::vector<char> correctedName = std::vector<char>();
 		while (*name != '\0') {
 			correctedName.push_back(correctChar(*name));
@@ -47,6 +53,7 @@ namespace eg
 
 	void NameNewProjectPanel::OnImGuiRender()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::SetNextWindowPos(ImVec2(Application::Get().GetWindow().GetWidth() / 2, Application::Get().GetWindow().GetHeight() / 2));
 
 		ImGui::Begin("Name project", &m_Show, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize);

--- a/Engine-Editor/src/Panels/ProjectDirectoryPanel.cpp
+++ b/Engine-Editor/src/Panels/ProjectDirectoryPanel.cpp
@@ -7,8 +7,10 @@
 
 namespace eg {
 	ProjectDirectoryPanel::ProjectDirectoryPanel() {
+		EG_PROFILE_FUNCTION();
 	}
 	int64_t getPathID(const std::string path) {
+		EG_PROFILE_FUNCTION();
 		static std::map<std::string, int64_t> paths;
 		try
 		{
@@ -23,6 +25,7 @@ namespace eg {
 	}
 
 	void ProjectDirectoryPanel::OnImGuiRender() {
+		EG_PROFILE_FUNCTION();
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.f, 0.f));
 		ImGui::Begin("Project Directory");
 		ImGui::PopStyleVar();
@@ -31,6 +34,7 @@ namespace eg {
 		ImGui::End();
 	}
 	void ProjectDirectoryPanel::DrawDirectoryTreeNode(const std::filesystem::path& path) {
+		EG_PROFILE_FUNCTION();
 
 		auto t = ImGui::GetItemID();
 		auto i = getPathID(path.string());

--- a/Engine-Editor/src/Panels/ProjectDirectoryPanel.h
+++ b/Engine-Editor/src/Panels/ProjectDirectoryPanel.h
@@ -11,7 +11,7 @@ namespace eg {
 		void SetContentBrowserPanel(Ref<ContentBrowserPanel> val) { m_ContentBrowserPanel = val; };
 	private:
 		std::string m_SearchedName;
-		Ref<ContentBrowserPanel> m_ContentBrowserPanel;
+		Ref<ContentBrowserPanel> m_ContentBrowserPanel = nullptr;
 
 		void DrawDirectoryTreeNode(const std::filesystem::path& path);
 	};

--- a/Engine-Editor/src/Panels/RenameFolderPanel.cpp
+++ b/Engine-Editor/src/Panels/RenameFolderPanel.cpp
@@ -6,16 +6,20 @@ namespace eg
 {
 	RenameFolderPanel::RenameFolderPanel()
 		: m_Show(false), m_DirectoryUUID(0)
-	{ }
+	{
+	    EG_PROFILE_FUNCTION();
+	}
 
 	void RenameFolderPanel::ShowWindow(UUID directoryUUID)
 	{
+		EG_PROFILE_FUNCTION();
 		m_DirectoryUUID = directoryUUID;
 		m_Show = true;
 	}
 
 	void RenameFolderPanel::OnImGuiRender()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::SetNextWindowPos(ImVec2(Application::Get().GetWindow().GetWidth() / 2, Application::Get().GetWindow().GetHeight() / 2));
 
 		ImGui::Begin("Rename folder", &m_Show, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize);

--- a/Engine-Editor/src/Panels/RenameResourcePanel.cpp
+++ b/Engine-Editor/src/Panels/RenameResourcePanel.cpp
@@ -6,16 +6,20 @@ namespace eg
 {
 	RenameResourcePanel::RenameResourcePanel()
 		: m_Show(false), m_UUID(0)
-	{ }
+	{
+	    EG_PROFILE_FUNCTION();
+	}
 
 	void RenameResourcePanel::ShowWindow(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		m_UUID = uuid;
 		m_Show = true;
 	}
 
 	void RenameResourcePanel::OnImGuiRender()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::SetNextWindowPos(ImVec2(Application::Get().GetWindow().GetWidth() / 2, Application::Get().GetWindow().GetHeight() / 2));
 
 		ImGui::Begin("Rename resource", &m_Show, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize);

--- a/Engine-Editor/src/Panels/ResourcesPanels/AnimationEditorPanel.cpp
+++ b/Engine-Editor/src/Panels/ResourcesPanels/AnimationEditorPanel.cpp
@@ -26,10 +26,12 @@ namespace eg {
 
 	AnimationEditorPanel::AnimationEditorPanel(UUID asset)
 	{
+        EG_PROFILE_FUNCTION();
 		OpenAnimationEditorPanel(asset);
 	}
 
 	bool AnimationEditorPanel::OpenAnimationEditorPanel(UUID asset) {
+        EG_PROFILE_FUNCTION();
 		ResetData();
 		ShowAnimationEditorPanel(true);
 		m_Anim = Animation::Create(asset);
@@ -39,6 +41,7 @@ namespace eg {
 	}
 
 	void AnimationEditorPanel::OnImGuiRender() {
+        EG_PROFILE_FUNCTION();
 		if (!m_ShowAnimationEditorPanel)
 			return;
 
@@ -63,21 +66,22 @@ namespace eg {
 		DrawFrameRate();
 
 		DrawExitButtons();
-		
+
 		ImGui::End();
-		
+
 		ImGui::PopStyleColor(7);
 	}
 
 	void AnimationEditorPanel::DrawAnimationPreview() {
+        EG_PROFILE_FUNCTION();
 
 		Ref<SubTexture2D> subTexture = m_Anim->GetFrame(m_DisplayedFrameIndex)->GetSubTexture();
 
 		ImGui::SetCursorPosX((ImGui::GetWindowSize().x - 300) * 0.5f);
-		ImGui::SetCursorPosY(100);  
+		ImGui::SetCursorPosY(100);
 		float spaceY = ImGui::GetCursorPos().y + 322;
 		int i = 0;
-		
+
 		if (m_Anim->GetFrameCount() > 0) {
 			ImGui::Image(
 				(void*)subTexture->GetTexture()->GetRendererID(),
@@ -89,18 +93,20 @@ namespace eg {
 					subTexture->GetMax().x,
 					subTexture->GetMin().y)
 			);
-			
+
 		}
 		ImGui::SetCursorPosY(spaceY);
 	}
 
 	void AnimationEditorPanel::Update(float dt)
 	{
+        EG_PROFILE_FUNCTION();
 		if (m_PlayAnimation)
 			m_Anim->Update(dt, 1.0f);
 	}
 
 	void AnimationEditorPanel::SetFrames() {
+        EG_PROFILE_FUNCTION();
 
 		m_Anim->SetFrame(0);
 		ResetSelectedFrames();
@@ -108,6 +114,7 @@ namespace eg {
 
 	void AnimationEditorPanel::ResetData()
 	{
+        EG_PROFILE_FUNCTION();
 		ResetSelectedFrames();
 		m_Anim = nullptr;
 		m_PlayAnimation = false;
@@ -125,6 +132,7 @@ namespace eg {
 
 	void AnimationEditorPanel::UpdateSelectedFrames()
 	{
+        EG_PROFILE_FUNCTION();
 		if (m_Move || m_Resize) {
 			ResetSelectedFrames();
 		}
@@ -147,17 +155,20 @@ namespace eg {
 
 	bool AnimationEditorPanel::IsFrameSelected(int frame)
 	{
+        EG_PROFILE_FUNCTION();
 		return m_SelectedFrames.first == frame || m_SelectedFrames.second == frame;
 	}
 
 	void AnimationEditorPanel::ResetSelectedFrames()
 	{
+        EG_PROFILE_FUNCTION();
 		m_SelectedFrames.first = -1;
 		m_SelectedFrames.second = -1;
 	}
 
 	void AnimationEditorPanel::UpdateDisplayedFrame()
 	{
+        EG_PROFILE_FUNCTION();
 		if(m_PlayAnimation)
 		{
 			m_DisplayedFrameIndex = m_Anim->GetCurrentFrame();
@@ -174,6 +185,7 @@ namespace eg {
 
 	void AnimationEditorPanel::DrawPlayButton()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
 		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0, 0, 0, 0));
 		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0, 0, 0, 0));
@@ -197,6 +209,7 @@ namespace eg {
 
 	void AnimationEditorPanel::DrawFunctionCallPopup()
 	{
+        EG_PROFILE_FUNCTION();
 		if (m_OpenFunctionCallPopup)
 		{
 			ImGui::OpenPopup("FunctionCallPopup");
@@ -241,8 +254,8 @@ namespace eg {
 
 			}
 			ImGui::EndPopup();
-			
-			
+
+
 		}
 		ImGui::PopStyleVar(2);
 		ImGui::PopStyleColor(7);
@@ -250,6 +263,7 @@ namespace eg {
 
 	void AnimationEditorPanel::DrawAnimationOptions()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::PushStyleColor(ImGuiCol_PopupBg, BGCOLOR);
 		ImGui::PushStyleColor(ImGuiCol_HeaderHovered, HOVEREDCOLOR);
 		ImGui::PushStyleColor(ImGuiCol_HeaderActive, ACTIVEINPUTCOLOR);
@@ -293,6 +307,7 @@ namespace eg {
 
 	void AnimationEditorPanel::DrawFrameTrack()
 	{
+        EG_PROFILE_FUNCTION();
 		float buttonGap = 10;
 		float rightMargin = 20;
 		ImVec2 buttonSize = ImVec2(30, 30);
@@ -301,9 +316,9 @@ namespace eg {
 		float startX = ImGui::GetCursorScreenPos().x + buttonSize.x + buttonGap ;
 		float startY = ImGui::GetCursorScreenPos().y + 25;
 		frameWidth = trackWidth / animationDuration < MINFRAMEWIDTH ? MINFRAMEWIDTH : trackWidth / animationDuration;
-		
+
 		DrawActionButtons(buttonSize, buttonGap);
-		
+
 		m_HoveredFrame = -1;
 		m_FrameReleased = false;
 
@@ -363,7 +378,7 @@ namespace eg {
 			hoverTime = 0.0f;
 		}
 		ImGui::SetCursorScreenPos(ImVec2(startX - buttonSize.x - buttonGap, ImGui::GetCursorScreenPos().y + 60));
-		
+
 		DrawAnimationOptions();
 		//DrawFunctionCallPopup();
 		//DrawFunctionInfoPopup();
@@ -375,11 +390,12 @@ namespace eg {
 		}
 
 		HandleResize();
-		
+
 	}
 
 	void AnimationEditorPanel::DrawFunctionInfoPopup()
 	{
+        EG_PROFILE_FUNCTION();
 		if(hoverTime < hoverTimeMax)
 			return;
 
@@ -405,6 +421,7 @@ namespace eg {
 
 	void AnimationEditorPanel::DrawFrameRate()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::PushStyleColor(ImGuiCol_FrameBg, BASEINPUTCOLOR);
 		ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, HOVEREDCOLOR);
 		ImGui::PushStyleColor(ImGuiCol_FrameBgActive, SELECTEDFRAMECOLOR);
@@ -416,6 +433,7 @@ namespace eg {
 
 	void AnimationEditorPanel::HandleFrameHover(int frameIndex, const ImVec2& cursorPos, const ImVec2& cursorPos2)
 	{
+        EG_PROFILE_FUNCTION();
 		if (ImGui::IsMouseHoveringRect(cursorPos, cursorPos2))
 
 		{
@@ -434,6 +452,7 @@ namespace eg {
 
 	void AnimationEditorPanel::HandleFrameLeftClick(int clickedFrameIndex)
 	{
+        EG_PROFILE_FUNCTION();
 		if (m_PlayAnimation || !ImGui::IsItemClicked(ImGuiMouseButton_Left))
 			return;
 		if (m_ClickedFrame == clickedFrameIndex) {
@@ -445,11 +464,12 @@ namespace eg {
 		}
 		UpdateSelectedFrames();
 		EG_TRACE("Clicked frame: {0}", clickedFrameIndex);
-		
+
 	}
 
 	void AnimationEditorPanel::HandleFrameRightClick(int clickedFrameIndex)
 	{
+        EG_PROFILE_FUNCTION();
 		if (m_PlayAnimation)
 			return;
 		if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
@@ -460,6 +480,7 @@ namespace eg {
 
 	void AnimationEditorPanel::HandleFrameDrag(int clickedFrameIndex)
 	{
+        EG_PROFILE_FUNCTION();
 		if (ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
 			if (!m_IsDragging) {
 				m_IsDragging = true;
@@ -476,6 +497,7 @@ namespace eg {
 
 	void AnimationEditorPanel::HandleFrameLeftClickRelease(int clickedFrameIndex)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!ImGui::IsMouseReleased(ImGuiMouseButton_Left) )
 			return;
 
@@ -484,6 +506,7 @@ namespace eg {
 
 	void AnimationEditorPanel::HandleResize()
 	{
+        EG_PROFILE_FUNCTION();
 		if(!m_Resize)
 			return;
 		if (!m_IsDragging || m_DraggingIndex == -1)
@@ -495,11 +518,12 @@ namespace eg {
 		if(estNewDuration != m_Anim->GetFrame(m_DraggingIndex)->GetFrameDuration())
 			m_Anim->GetFrame(m_DraggingIndex)->SetFrameDuration(estNewDuration);
 		SetFrames();
-		
+
 	}
 
 	void AnimationEditorPanel::HandleMove(int moveTo)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!m_Move)
 			return;
 		if (!m_IsDragging || m_DraggingIndex == -1)
@@ -509,11 +533,12 @@ namespace eg {
 			m_Anim->MoveFrame(m_DraggingIndex, moveTo);
 			SetFrames();
 		}
-		
+
 	}
 
 	void AnimationEditorPanel::DrawActionButtons(const ImVec2& buttonSize, float gap)
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 5);
 		ImVec4 moveIconTint = m_Move ? ImVec4(1, 1, 1, 1) : ImVec4(0.75, 0.75, 0.75, 1);
 		ImVec4 resizeIconTint = m_Resize ? ImVec4(1, 1, 1, 1) : ImVec4(0.75, 0.75, 0.75, 1);
@@ -533,6 +558,7 @@ namespace eg {
 
 	void AnimationEditorPanel::DrawExitButtons()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::SetCursorScreenPos(ImVec2(ImGui::GetCursorScreenPos().x, ImGui::GetCursorScreenPos().y + BASEGAP));
 
 		ImGui::PushStyleColor(ImGuiCol_Button, BASEINPUTCOLOR);
@@ -564,6 +590,7 @@ namespace eg {
 
 	uint32_t AnimationEditorPanel::GetFrameColor(int frame)
 	{
+        EG_PROFILE_FUNCTION();
 		if (m_IsDragging && m_DraggingIndex == frame)
 			return ACTIVEINPUTCOLOR;
 		if (IsFrameSelected(frame))

--- a/Engine-Editor/src/Panels/ResourcesPanels/AnimationPanel.cpp
+++ b/Engine-Editor/src/Panels/ResourcesPanels/AnimationPanel.cpp
@@ -12,6 +12,7 @@ namespace eg {
 	namespace Utils {
 		ImVec4 ColorFromHexNoAlpha(unsigned int hexColor)
 		{
+            EG_PROFILE_FUNCTION();
 			float r = ((hexColor >> 16) & 0xFF) / 255.0f;
 			float g = ((hexColor >> 8) & 0xFF) / 255.0f;
 			float b = (hexColor & 0xFF) / 255.0f;
@@ -40,10 +41,11 @@ namespace eg {
 
 	bool AnimationPanel::OpenAnimationPanel(const std::filesystem::path& path)
 	{
+        EG_PROFILE_FUNCTION();
 		EG_PROFILE_FUNCTION();
 		ShowAnimationPanel(true);
 		m_FrameData = CreateRef<FrameData>();
-		
+
 		std::filesystem::path textureBasePath = Project::GetProjectDirectory() / Project::GetAssetDirectory() / "Animations";
 		bool resourceLoad = false;
 		m_LoadedResource = new Resource();
@@ -75,12 +77,12 @@ namespace eg {
 		m_ResourceData->Extension = ".anim";
 
 		m_ImageAspectRatio = (float)m_PreviewOriginImage->GetWidth() / (float)m_PreviewOriginImage->GetHeight();
-		if (m_ImageAspectRatio < 1.0f) 
+		if (m_ImageAspectRatio < 1.0f)
 		{
 			m_BasePreviewWidthImage = 256 * m_ImageAspectRatio;
 			m_BasePreviewHeightImage = 256;
 		}
-		else 
+		else
 		{
 			m_BasePreviewWidthImage = 256;
 			m_BasePreviewHeightImage = 256 / m_ImageAspectRatio;
@@ -96,6 +98,7 @@ namespace eg {
 
 	void AnimationPanel::SetFrames()
 	{
+        EG_PROFILE_FUNCTION();
 		EG_PROFILE_FUNCTION();
 		m_PreviewData->ClearFrames();
 
@@ -131,6 +134,7 @@ namespace eg {
 
 	void AnimationPanel::SetSelectedFrames()
 	{
+        EG_PROFILE_FUNCTION();
 		EG_PROFILE_FUNCTION();
 		m_SelectedFrames.clear();
 		for (int i = m_Row; i < m_RowCount + m_Row; i++)
@@ -141,6 +145,7 @@ namespace eg {
 
 	void AnimationPanel::ClearOutdatedFrames()
 	{
+        EG_PROFILE_FUNCTION();
 		EG_PROFILE_FUNCTION();
 		std::vector<std::pair<int, int>> newSelectedFrames;
 		for (auto frame : m_SelectedFrames)
@@ -155,6 +160,7 @@ namespace eg {
 
 	void AnimationPanel::DeleteData()
 	{
+        EG_PROFILE_FUNCTION();
 		EG_PROFILE_FUNCTION();
 		if (m_LoadedResource)
 		{
@@ -173,6 +179,7 @@ namespace eg {
 
 	void AnimationPanel::SaveData()
 	{
+        EG_PROFILE_FUNCTION();
 		m_ResourceData->Frames.clear();
 		m_ResourceData->Frames.reserve(m_PreviewData->GetFrameCount());
 
@@ -213,6 +220,7 @@ namespace eg {
 
 	void AnimationPanel::DrawSubtexture(const int& i,const int& j)
 	{
+        EG_PROFILE_FUNCTION();
 		if (j != 0)
 			ImGui::SameLine();
 		ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 1.0f);
@@ -258,6 +266,7 @@ namespace eg {
 
 	void AnimationPanel::DrawFrameSelection()
 	{
+        EG_PROFILE_FUNCTION();
 		EG_PROFILE_FUNCTION();
 		float contentRegionAvailX = ImGui::GetContentRegionAvail().x;
 		ImGui::PushItemWidth(DRAGINTWIDTH);
@@ -274,10 +283,10 @@ namespace eg {
 			SetFrames();
 		}
 
-		 
-		ImGui::SameLine();  
+
+		ImGui::SameLine();
 		ImGui::SetCursorPosX(ImGui::GetCursorPosX() + BASEGAP + ADDITIONALGAP);
-		
+
 		if (ImGui::DragInt("Row count", &m_MaxRow, 1.0f, 1, m_TextureData->Height))
 		{
 			if (m_MaxRow < 1)
@@ -289,7 +298,7 @@ namespace eg {
 			ClearOutdatedFrames();
 			SetFrames();
 		}
-		
+
 
 		if (ImGui::DragInt("Begin Column", &m_Column, 1.0f, 0, m_MaxColumn-1))
 		{
@@ -352,11 +361,11 @@ namespace eg {
 				for (int j = 0; j < (int)(m_PreviewOriginImage->GetWidth() / m_FrameWidth); j++) {
 					std::pair<int, int> frameIndex = std::make_pair(i, j);
 					m_SelectedFrames.emplace_back(frameIndex);
-					
+
 				}
 			SetFrames();
 		}
-		
+
 		ImGui::SameLine();
 		if (ImGui::Button("Select none", ImVec2(90, 40))) {
 			m_SelectedFrames.clear();
@@ -368,6 +377,7 @@ namespace eg {
 
 	void AnimationPanel::DrawAnimInfo()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::SetCursorPosY(ImGui::GetCursorPosY() + BASEGAP);
 		ImGui::Checkbox("Play", m_PreviewData->IsPlayingPtr());
 
@@ -382,7 +392,7 @@ namespace eg {
 		if (ImGui::DragInt("Frame Rate", m_PreviewData->GetFrameRatePtr(), 1.0f, 0.0f, 500)) {
 			SetFrames();
 		}
-		
+
 		char buffer[512];
 		memset(buffer, 0, sizeof(buffer));
 		std::strncpy(buffer, m_ResourceData->ResourceName.c_str(), sizeof(buffer));
@@ -394,6 +404,7 @@ namespace eg {
 
 	void AnimationPanel::DrawAnimationPreview()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::SetCursorPosY(ImGui::GetCursorPosY() + BASEGAP);
 		ImGui::Text("Animation Preview:");
 		if (m_PreviewData->GetFrameCount() > 0)
@@ -413,6 +424,7 @@ namespace eg {
 
 	void AnimationPanel::OnImGuiRender()
 	{
+        EG_PROFILE_FUNCTION();
 		EG_PROFILE_FUNCTION();
 		if (!m_ShowAnimationPanel)
 			return;
@@ -447,11 +459,11 @@ namespace eg {
 				DrawSubtexture(i, j);
 			}
 		}
-		
+
 		DrawAnimInfo();
-		
+
 		DrawAnimationPreview();
-		
+
 		ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(20, 20));
 		ImGui::SetCursorPosY(ImGui::GetCursorPosY() + BASEGAP);
 
@@ -474,6 +486,7 @@ namespace eg {
 
 	void AnimationPanel::CloseAnimationPanel()
 	{
+        EG_PROFILE_FUNCTION();
 		EG_PROFILE_FUNCTION();
 		DeleteData();
 		ResetData();
@@ -482,6 +495,7 @@ namespace eg {
 
 	void AnimationPanel::ResetData()
 	{
+        EG_PROFILE_FUNCTION();
 		EG_PROFILE_FUNCTION();
 		m_FrameWidth = 0;
 		m_FrameHeight = 0;

--- a/Engine-Editor/src/Panels/ResourcesPanels/ImagePanel.cpp
+++ b/Engine-Editor/src/Panels/ResourcesPanels/ImagePanel.cpp
@@ -21,18 +21,20 @@ namespace eg
 
 	ImagePanel::ImagePanel(const std::filesystem::path& path)
 	{
+        EG_PROFILE_FUNCTION();
 		m_TexturePath = path;
 	}
 
 	bool ImagePanel::OpenImagePanel(const std::filesystem::path& path)
 	{
+        EG_PROFILE_FUNCTION();
 		m_TexturePath = path;
 		/*m_TextureData.ResourcePath = path;*/
 		m_BasePath = Project::GetProjectDirectory() / Project::GetAssetDirectory() / "Textures";
 		bool resourceLoad = false;
 		m_LoadedResource = new Resource();
 		resourceLoad = resourceSystemLoad(path.string(), ResourceType::Image, m_LoadedResource);
-		
+
 		if (!resourceLoad) {
 			return false;
 		}
@@ -54,6 +56,7 @@ namespace eg
 
 	void ImagePanel::OnImGuiRender()
 	{
+        EG_PROFILE_FUNCTION();
 		if (!m_ShowImagePanel)
 			return;
                 ImGui::PushStyleColor(ImGuiCol_WindowBg, BGCOLOR);
@@ -114,6 +117,7 @@ namespace eg
 	}
 	void ImagePanel::ResetData()
 	{
+        EG_PROFILE_FUNCTION();
 		m_TextureData = TextureResourceData();
 		m_TextureData.ParentDirectory = 0;
 		m_TextureData.ResourceName = "";

--- a/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
+++ b/Engine-Editor/src/Panels/SceneHierarchyPanel.cpp
@@ -34,6 +34,7 @@ namespace eg
 
 	const char *add(const char *begining, const char *middle, const char *ending)
 	{
+        EG_PROFILE_FUNCTION();
 		size_t resultLength = strlen(middle) + strlen(begining) + strlen(ending);
 		char *resultMsg = new char[resultLength];
 		strcpy(resultMsg, begining);
@@ -44,6 +45,7 @@ namespace eg
 
 	float CalculatePreferedComponentPropertyWidth(const char *label)
 	{
+        EG_PROFILE_FUNCTION();
 		float WidthOfLabel = ImGui::CalcTextSize(label).x;
 		if (WidthOfLabel > ImGui::GetContentRegionAvail().x * (1.f - WidthOfProperty) - 4.f)
 		{
@@ -64,6 +66,7 @@ namespace eg
 
 	static void PropertyLabel(const char *label)
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::SameLine();
 		bool s = ImGui::TextWrappedWithLineLimit(label, 1);
 
@@ -79,6 +82,7 @@ namespace eg
 
 	static bool PrettyButton(const char *label, bool fullWidth = false)
 	{
+        EG_PROFILE_FUNCTION();
 		if (fullWidth)
 			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(50, 7));
 		else
@@ -98,11 +102,14 @@ namespace eg
 
 	void ComponentPropertyBeforeDraw(const char *label)
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::PushID(label);
 		ImGui::PushItemWidth(CalculatePreferedComponentPropertyWidth(label));
 	}
+
 	void ComponentPropertyAfterDraw(const char *label)
 	{
+		EG_PROFILE_FUNCTION();
 		ImGui::PopItemWidth();
 		PropertyLabel(label);
 		ImGui::PopID();
@@ -110,6 +117,7 @@ namespace eg
 
 	static void DrawVec3Control(Entity entity, const std::string &label, glm::vec3 &values, float resetValue = 0.0f, float columnWidth = 100.0f, bool firstValue = false)
 	{
+		EG_PROFILE_FUNCTION();
 		float x = values.x, y = values.y, z = values.z;
 		ImGuiIO &io = ImGui::GetIO();
 		auto boldFont = io.Fonts->Fonts[0];
@@ -187,6 +195,7 @@ namespace eg
 
 	static bool DrawComponentPropertyFloat(const char *label, float *value, float speed = 1.0f, float min = 0.0f, float max = 0.0f, const char *format = "%.3f")
 	{
+		EG_PROFILE_FUNCTION();
 
 		ComponentPropertyBeforeDraw(label);
 		bool changed_value = ImGui::DragFloat("", value, speed, min, max, format);
@@ -196,7 +205,7 @@ namespace eg
 
 	static bool DrawComponentPropertyFloat2(const char *label, float value[2], float speed = 1.0f, float min = 0.0f, float max = 0.0f, const char *format = "%.3f")
 	{
-
+		EG_PROFILE_FUNCTION();
 		ComponentPropertyBeforeDraw(label);
 		bool changed_value = ImGui::DragFloat2("", value, speed, min, max, format);
 		ComponentPropertyAfterDraw(label);
@@ -205,7 +214,7 @@ namespace eg
 
 	static bool DrawComponentPropertyFloat3(const char *label, float value[3], float speed = 1.0f, float min = 0.0f, float max = 0.0f, const char *format = "%.3f")
 	{
-
+		EG_PROFILE_FUNCTION();
 		ComponentPropertyBeforeDraw(label);
 		bool changed_value = ImGui::DragFloat3("", value, speed, min, max, format);
 		ComponentPropertyAfterDraw(label);
@@ -214,7 +223,7 @@ namespace eg
 
 	static bool DrawComponentPropertyFloat4(const char *label, float value[4], float speed = 1.0f, float min = 0.0f, float max = 0.0f, const char *format = "%.3f")
 	{
-
+		EG_PROFILE_FUNCTION();
 		ComponentPropertyBeforeDraw(label);
 		bool changed_value = ImGui::DragFloat4("", value, speed, min, max, format);
 		ComponentPropertyAfterDraw(label);
@@ -223,7 +232,7 @@ namespace eg
 
 	static bool DrawComponentPropertyInt(const char *label, int *value, float speed = 1.0f, float min = 0.0f, float max = 0.0f, const char *format = "%d")
 	{
-
+		EG_PROFILE_FUNCTION();
 		ComponentPropertyBeforeDraw(label);
 		bool changed_value = ImGui::DragInt("", value, speed, min, max, format);
 		ComponentPropertyAfterDraw(label);
@@ -232,7 +241,7 @@ namespace eg
 
 	static bool DrawComponentPropertyColorEdit4(const char *label, float col[4])
 	{
-
+		EG_PROFILE_FUNCTION();
 		ComponentPropertyBeforeDraw(label);
 		bool changed_value = ImGui::ColorEdit4("", col);
 		ComponentPropertyAfterDraw(label);
@@ -241,6 +250,7 @@ namespace eg
 
 	static bool DrawComponentPropertyInputText(const char *label, char *buf, size_t buf_size)
 	{
+		EG_PROFILE_FUNCTION();
 		ComponentPropertyBeforeDraw(label);
 		bool changed = ImGui::InputText("", buf, buf_size);
 		ComponentPropertyAfterDraw(label);
@@ -249,6 +259,7 @@ namespace eg
 
 	static bool DrawComponentPropertyInputText(const char *label, std::string *val)
 	{
+		EG_PROFILE_FUNCTION();
 		ComponentPropertyBeforeDraw(label);
 		bool changed = ImGui::InputText("", val);
 		ComponentPropertyAfterDraw(label);
@@ -257,6 +268,7 @@ namespace eg
 
 	static void DrawComponentPropertyFileReference(const char *label, UUID &uuid, std::function<void(int64_t *what)> fun)
 	{
+		EG_PROFILE_FUNCTION();
 		ComponentPropertyBeforeDraw(label);
 		ImGui::Button((uuid == 0) ? "none" : ResourceDatabase::GetResourceName(uuid).c_str(), {CalculatePreferedComponentPropertyWidth(label), 0});
 		if (ImGui::BeginDragDropTarget())
@@ -273,6 +285,7 @@ namespace eg
 
 	static bool DrawComponentPropertyCheckbox(const char *label, bool *CheckedValue)
 	{
+		EG_PROFILE_FUNCTION();
 		ImGui::PushID(label);
 		bool changed_value = ImGui::Checkbox("", CheckedValue);
 		PropertyLabel(label);
@@ -282,6 +295,7 @@ namespace eg
 
 	static void DrawComponentPropertyCombo(const char *label, std::vector<const char *> possiblevalues, int currentSelected, std::function<void(int number)> fun)
 	{
+		EG_PROFILE_FUNCTION();
 		ImGui::PushID(label);
 		ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x * WidthOfProperty - 4.f);
 		char *currentValueString = (char *)possiblevalues[currentSelected];
@@ -309,11 +323,13 @@ namespace eg
 
 	SceneHierarchyPanel::SceneHierarchyPanel(const Ref<Scene> &scene)
 	{
+        EG_PROFILE_FUNCTION();
 		SetContext(scene);
 	}
 
 	void SceneHierarchyPanel::SetContext(const Ref<Scene> &scene)
 	{
+        EG_PROFILE_FUNCTION();
 		m_Context = scene;
 		EditorActions::SetScene(scene);
 		m_SelectionContext = {};
@@ -325,6 +341,7 @@ namespace eg
 
 	std::optional<EntityDisplayInfo> SceneHierarchyPanel::SearchEntity(Entity entity)
 	{
+        EG_PROFILE_FUNCTION();
 		bool searched = false, childsearched = false;
 		EntityDisplayInfo currentEntityDisplayInfo = EntityDisplayInfo();
 		for (Entity e : entity.GetChildren())
@@ -352,6 +369,7 @@ namespace eg
 
 	void SceneHierarchyPanel::Search()
 	{
+		EG_PROFILE_FUNCTION();
 		m_ListOfEntityDisplayed.clear();
 		m_Context->m_Registry.each([&](auto entityID)
 								   {
@@ -374,6 +392,7 @@ namespace eg
 
 	void SceneHierarchyPanel::OnImGuiRender()
 	{
+		EG_PROFILE_FUNCTION();
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.f, 0.f));
 		ImGui::Begin("Scene Hierarchy");
 		ImGui::PopStyleVar();
@@ -521,6 +540,7 @@ namespace eg
 
 	void SceneHierarchyPanel::Update(float dt)
 	{
+		EG_PROFILE_FUNCTION();
 		if (m_SelectionContext)
 		{
 			if (m_SelectionContext.HasComponent<AnimatorComponent>())
@@ -538,6 +558,7 @@ namespace eg
 
 	void SceneHierarchyPanel::DrawEntityNode(EntityDisplayInfo entityDisplayInfo)
 	{
+		EG_PROFILE_FUNCTION();
 		Entity entity = entityDisplayInfo.entity;
 
 		if (!entity.IsDrawable())
@@ -634,9 +655,11 @@ namespace eg
 			ImGui::TreePop();
 		}
 	}
+
 	template <typename T, typename UIFunction>
 	void SceneHierarchyPanel::DrawComponent(const std::string &name, Entity entity, UIFunction uiFunction, Ref<Scene> &context, Icons icon)
 	{
+		EG_PROFILE_FUNCTION();
 		static const ImGuiTreeNodeFlags treeNodeFlags = ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_AllowItemOverlap | ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_SpanAvailWidth | ImGuiTreeNodeFlags_FramePadding | ImGuiTreeNodeFlags_NoArrow | ImGuiTreeNodeFlags_PropertiesComponent;
 		if (entity.HasComponent<T>())
 		{
@@ -717,6 +740,7 @@ namespace eg
 	template <typename T>
 	void SceneHierarchyPanel::DisplayAddComponentEntry(const std::string &entryName)
 	{
+		EG_PROFILE_FUNCTION();
 		if (!m_SelectionContext.HasComponent<T>())
 		{
 			if (ImGui::MenuItem(entryName.c_str()))
@@ -729,12 +753,13 @@ namespace eg
 
 	void SceneHierarchyPanel::DrawComponents(Entity entity)
 	{
+		EG_PROFILE_FUNCTION();
 		if (entity.HasComponent<TagComponent>())
 		{
 			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(10, 7));
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 10.f);
 			ImGui::SetCursorPos({ ImGui::GetCursorPosX() + 40, ImGui::GetCursorPosY() + 20 });
-			ImGui::Image((ImTextureID)IconLoader::GetIcon(Icons::Component_Puzzle)->GetRendererID(), { 30, 30 });
+			ImGui::Image((ImTextureID)(IconLoader::GetIcon(Icons::Component_Puzzle)->GetRendererID()), { 30, 30 });
 			ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x - 120);
 			ImGui::SameLine();
 			ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 10);

--- a/Engine-Editor/src/Panels/WelcomingPanel.cpp
+++ b/Engine-Editor/src/Panels/WelcomingPanel.cpp
@@ -7,12 +7,14 @@ namespace eg
 	WelcomingPanel::WelcomingPanel(std::vector<std::string> list, RecentProjectSerializer m_RecentProjectSerializer)
 		: m_Show(true), m_DirectoryUUID(0), m_ProjectList(list), m_Rps(m_RecentProjectSerializer)
 	{
+        EG_PROFILE_FUNCTION();
 		m_NewProjectCreated = false;
 		m_SelectedProject = "";
 	}
 
 	void WelcomingPanel::ShowWindow(UUID directoryUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		m_Show = true;
 		m_DirectoryUUID = directoryUUID;
 	}
@@ -22,6 +24,7 @@ namespace eg
 
 	void WelcomingPanel::OnImGuiRender()
 	{
+        EG_PROFILE_FUNCTION();
 		ImGui::Begin("WelcomingPanel", &m_Show , ImGuiWindowFlags_NoTitleBar| ImGuiViewportFlags_NoDecoration);
 		ImGui::SetWindowFontScale(2.2);
 		ImGui::Text("Muniffic Engine");

--- a/Engine/src/Engine/Assistant/AssistantManager.cpp
+++ b/Engine/src/Engine/Assistant/AssistantManager.cpp
@@ -12,6 +12,7 @@ namespace eg
 {
 	AssistantManager::AssistantManager()
 	{
+		EG_PROFILE_FUNCTION();
 		IsVoiceAssistantListening = false;
 		newVoiceMessageAvailable = false;
 		IsVoiceAsssistantInitialized = false;
@@ -24,6 +25,7 @@ namespace eg
 
 	bool AssistantManager::ThreadAvailable(std::string threadID)
 	{
+		EG_PROFILE_FUNCTION();
 		if (m_Threads.find(threadID) == m_Threads.end())
 		{
 			EG_CORE_ERROR("Thread not found");
@@ -41,6 +43,7 @@ namespace eg
 
 	const std::string& AssistantManager::GetLastMessageRole(std::string threadID)
 	{
+		EG_PROFILE_FUNCTION();
 		if (m_Threads.find(threadID) == m_Threads.end())
 		{
 			EG_CORE_ERROR("Thread not found");
@@ -58,6 +61,7 @@ namespace eg
 
 	void AssistantManager::SpeakText(std::string text)
 	{
+		EG_PROFILE_FUNCTION();
 		PyGILState_STATE gstate = PyGILState_Ensure();
 
 		if (!IsVoiceAsssistantInitialized)
@@ -83,6 +87,7 @@ namespace eg
 
 	bool AssistantManager::CheckMicrophoneAvailable()
 	{
+		EG_PROFILE_FUNCTION();
 		PyGILState_STATE gstate = PyGILState_Ensure();
 
 		PyObject* result = PyObject_CallObject(m_CheckMicrophoneAvailable, nullptr);
@@ -100,6 +105,7 @@ namespace eg
 
 	void AssistantManager::SetVolume(float volume)
 	{
+		EG_PROFILE_FUNCTION();
 		PyGILState_STATE gstate = PyGILState_Ensure();
 
 		PyObject* args = PyTuple_Pack(1, PyFloat_FromDouble(volume));
@@ -117,6 +123,7 @@ namespace eg
 
 	void AssistantManager::StopListening()
 	{
+		EG_PROFILE_FUNCTION();
 		PyGILState_STATE gstate = PyGILState_Ensure();
 
 		PyObject_CallObject(m_stopVoiceAssistant, nullptr);
@@ -126,6 +133,7 @@ namespace eg
 
 	void AssistantManager::StartListening()
 	{
+		EG_PROFILE_FUNCTION();
 		IsVoiceAssistantListening = true;
 
 		PyGILState_STATE gstate = PyGILState_Ensure();
@@ -143,7 +151,7 @@ namespace eg
 			PyGILState_Release(gstate);
 			IsVoiceAssistantListening = false;
 			EG_CORE_ERROR("Failed to get voice message");
-			
+
 			return;
 		}
 
@@ -157,6 +165,7 @@ namespace eg
 
 	void AssistantManager::Init()
 	{
+		EG_PROFILE_FUNCTION();
 		Py_Initialize();
 		PyEval_InitThreads();
 
@@ -233,6 +242,7 @@ namespace eg
 
 	bool AssistantManager::CheckAPI()
 	{
+		EG_PROFILE_FUNCTION();
 		PyGILState_STATE gstate = PyGILState_Ensure();
 
 		PyObject* result = PyObject_CallObject(m_CheckAPI, nullptr);
@@ -251,6 +261,7 @@ namespace eg
 
 	bool AssistantManager::CreateAssistant(std::string assistantName, std::string assistantInstructions = "")
 	{
+		EG_PROFILE_FUNCTION();
 		PyGILState_STATE gstate = PyGILState_Ensure();
 
 		PyObject* args = PyTuple_Pack(3, PyUnicode_FromString(assistantName.c_str()), PyUnicode_FromString("gpt-4o-mini"), PyUnicode_FromString(assistantInstructions.c_str()));
@@ -270,7 +281,7 @@ namespace eg
 			EG_CORE_ERROR("Failed to call create_assistant function");
 			return false;
 		}
-			
+
 		EG_CORE_INFO("Assistant created with ID: {0}", PyUnicode_AsUTF8(result));
 
 		m_AssistantID = PyUnicode_AsUTF8(result);
@@ -284,6 +295,7 @@ namespace eg
 
 	std::string AssistantManager::CreateThread()
 	{
+		EG_PROFILE_FUNCTION();
 		PyGILState_STATE gstate = PyGILState_Ensure();
 
 		PyObject* result = PyObject_CallObject(m_CreateThread, nullptr);
@@ -305,10 +317,11 @@ namespace eg
 
 	void AssistantManager::InitiateRun(std::string threadID)
 	{
+		EG_PROFILE_FUNCTION();
 		if (m_Threads.find(threadID) == m_Threads.end())
 		{
 			EG_CORE_ERROR("Thread not found");
-			
+
 			return;
 		}
 
@@ -321,7 +334,7 @@ namespace eg
 			PyErr_Print();
 			EG_CORE_ERROR("Failed to create args object");
 			PyGILState_Release(gstate);
-			
+
 			return;
 		}
 
@@ -332,7 +345,7 @@ namespace eg
 			PyErr_Print();
 			EG_CORE_ERROR("Failed to call initiate_run function");
 			PyGILState_Release(gstate);
-			
+
 			return;
 		}
 
@@ -344,10 +357,11 @@ namespace eg
 
 	void AssistantManager::AddMessage(std::string threadID, std::string message)
 	{
+		EG_PROFILE_FUNCTION();
 		if (m_Threads.find(threadID) == m_Threads.end())
 		{
 			EG_CORE_ERROR("Thread not found");
-			
+
 			return;
 		}
 
@@ -369,7 +383,7 @@ namespace eg
 
 			delete messageObj;
 			m_Threads.at(threadID)->messages.pop_back();
-			
+
 			return;
 		}
 
@@ -381,17 +395,18 @@ namespace eg
 
 	bool AssistantManager::WaitForCompletion(std::string threadID)
 	{
+		EG_PROFILE_FUNCTION();
 		if (m_Threads.find(threadID) == m_Threads.end())
 		{
 			EG_CORE_ERROR("Thread not found");
-			
+
 			return false;
 		}
 
 		if (m_Threads.at(threadID)->m_RunIDs.size() == 0)
 		{
 			EG_CORE_ERROR("No run IDs found for thread");
-			
+
 			return false;
 		}
 
@@ -406,7 +421,7 @@ namespace eg
 			PyErr_Print();
 			EG_CORE_ERROR("Failed to create args object");
 			PyGILState_Release(gstate);
-			
+
 			return false;
 		}
 
@@ -417,7 +432,7 @@ namespace eg
 			PyErr_Print();
 			EG_CORE_ERROR("Failed to call wait_for_completion function");
 			PyGILState_Release(gstate);
-			
+
 			return false;
 		}
 
@@ -432,7 +447,7 @@ namespace eg
 				PyErr_Print();
 				EG_CORE_ERROR("Failed to create args object");
 				PyGILState_Release(gstate);
-				
+
 				return false;
 			}
 
@@ -443,7 +458,7 @@ namespace eg
 				PyErr_Print();
 				EG_CORE_ERROR("Failed to call get_last_message function");
 				PyGILState_Release(gstate);
-				
+
 				return false;
 			}
 
@@ -463,7 +478,7 @@ namespace eg
 			}
 			else
 				IsMessageInProgress = false;
-			
+
 			m_Threads.at(threadID)->messages.push_back(messageObj);
 
 			return true;
@@ -476,17 +491,18 @@ namespace eg
 		{
 			EG_CORE_ERROR("Run " + status);
 			PyGILState_Release(gstate);
-			
+
 			return false;
 		}
 
 		PyGILState_Release(gstate);
-		
+
 		return false;
 	}
 
 	bool AssistantManager::TakeAction(std::string threadID, std::string runID, PyGILState_STATE gstate)
 	{
+		EG_PROFILE_FUNCTION();
 		PyObject* args = PyTuple_Pack(2, PyUnicode_FromString(threadID.c_str()), PyUnicode_FromString(runID.c_str()));
 
 		if (args == nullptr)
@@ -494,7 +510,7 @@ namespace eg
 			PyErr_Print();
 			EG_CORE_ERROR("Failed to create args object");
 			PyGILState_Release(gstate);
-			
+
 			return false;
 		}
 
@@ -505,7 +521,7 @@ namespace eg
 			PyErr_Print();
 			EG_CORE_ERROR("Failed to call get_tool_call function");
 			PyGILState_Release(gstate);
-			
+
 			return false;
 		}
 
@@ -603,7 +619,7 @@ namespace eg
 					PyErr_Print();
 					EG_CORE_ERROR("Failed to create args object");
 					PyGILState_Release(gstate);
-					
+
 					return false;
 				}
 
@@ -614,7 +630,7 @@ namespace eg
 					PyErr_Print();
 					EG_CORE_ERROR("Failed to call submit_tool_outputs function");
 					PyGILState_Release(gstate);
-					
+
 					return false;
 				}
 			}
@@ -625,6 +641,7 @@ namespace eg
 
 	void AssistantManager::SaveAssistant()
 	{
+		EG_PROFILE_FUNCTION();
 		std::filesystem::path path = Project::GetResourcesPath() / "resources/assistant/assistant.mndata";
 		YAML::Emitter out;
 
@@ -642,6 +659,7 @@ namespace eg
 
 	bool AssistantManager::LoadAssistant()
 	{
+		EG_PROFILE_FUNCTION();
 		std::filesystem::path path = "resources/assistant/assistant.mndata";
 
 		if (!std::filesystem::exists(path))
@@ -649,7 +667,7 @@ namespace eg
 			std::filesystem::create_directories(path.parent_path());
 			std::ofstream file(path.string(), std::ios::trunc);
 			file.close();
-			
+
 			return false;
 		}
 
@@ -662,7 +680,7 @@ namespace eg
 		catch (YAML::ParserException e)
 		{
 			EG_CORE_ERROR("Failed to load assistant data");
-			
+
 			return false;
 		}
 
@@ -670,26 +688,27 @@ namespace eg
 			m_AssistantID = data["assistantID"].as<std::string>();
 		else
 		{
-			
+
 			return false;
 		}
 
 		if (!CheckIfAssistantExists(m_AssistantID))
 		{
 			EG_CORE_ERROR("Assistant with ID {0} does not exist", m_AssistantID);
-			
+
 			return false;
 		}
 
 		EG_CORE_INFO("Assistant loaded with ID: {0}", m_AssistantID);
 
-		
+
 
 		return true;
 	}
 
 	bool AssistantManager::CheckIfAssistantExists(std::string assistantID)
 	{
+		EG_PROFILE_FUNCTION();
 		PyGILState_STATE gstate = PyGILState_Ensure();
 
 		PyObject* args = PyTuple_Pack(1, PyUnicode_FromString(assistantID.c_str()));
@@ -698,7 +717,7 @@ namespace eg
 		{
 			PyErr_Print();
 			EG_CORE_ERROR("Failed to create args object");
-			
+
 			return false;
 		}
 
@@ -708,13 +727,13 @@ namespace eg
 		{
 			PyErr_Print();
 			EG_CORE_ERROR("Failed to call check_if_assistant_exists function");
-			
+
 			return false;
-		}	
+		}
 
 		PyGILState_Release(gstate);
 
-		
+
 
 		return PyObject_IsTrue(result);
 	}

--- a/Engine/src/Engine/Audio/BasicAudio.cpp
+++ b/Engine/src/Engine/Audio/BasicAudio.cpp
@@ -3,10 +3,12 @@
 
 namespace eg {
 	BasicAudio::BasicAudio(std::string& path) {
+		EG_PROFILE_FUNCTION();
 		m_Path = std::filesystem::path(path);
 	}
 
 	void BasicAudio::InitializeXAudio2() {
+		EG_PROFILE_FUNCTION();
 		hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 		if (FAILED(hr))
 			EG_CORE_TRACE(hr);
@@ -21,6 +23,7 @@ namespace eg {
 	}
 	HRESULT BasicAudio::FindChunk(HANDLE hFile, DWORD fourcc, DWORD& dwChunkSize, DWORD& dwChunkDataPosition)
 	{
+		EG_PROFILE_FUNCTION();
 		HRESULT hr = S_OK;
 		if (INVALID_SET_FILE_POINTER == SetFilePointer(hFile, 0, NULL, FILE_BEGIN))
 			return HRESULT_FROM_WIN32(GetLastError());
@@ -76,6 +79,7 @@ namespace eg {
 
 	HRESULT BasicAudio::ReadChunkData(HANDLE hFile, void* buffer, DWORD buffersize, DWORD bufferoffset)
 	{
+		EG_PROFILE_FUNCTION();
 		HRESULT hr = S_OK;
 		if (INVALID_SET_FILE_POINTER == SetFilePointer(hFile, bufferoffset, NULL, FILE_BEGIN))
 			return HRESULT_FROM_WIN32(GetLastError());
@@ -133,8 +137,8 @@ namespace eg {
 		BYTE* pDataBuffer = new BYTE[dwChunkSize];
 		ReadChunkData(hFile, pDataBuffer, dwChunkSize, dwChunkPosition);
 
-		buffer.AudioBytes = dwChunkSize;  
-		buffer.pAudioData = pDataBuffer;  
+		buffer.AudioBytes = dwChunkSize;
+		buffer.pAudioData = pDataBuffer;
 		buffer.Flags = XAUDIO2_END_OF_STREAM;
 		if (looped) buffer.LoopCount = XAUDIO2_LOOP_INFINITE;
 		if (FAILED(hr = pXAudio2->CreateSourceVoice(&pSourceVoice, (WAVEFORMATEX*)&wfx))) EG_CORE_TRACE(hr);
@@ -142,15 +146,17 @@ namespace eg {
 		if (FAILED(hr = pSourceVoice->SubmitSourceBuffer(&buffer)))
 			EG_CORE_TRACE(hr);
 		if (FAILED(hr = pSourceVoice->Start(0))) EG_CORE_TRACE(hr);
-			
+
 		return true;
 	}
 
 	void BasicAudio::Stop() {
+		EG_PROFILE_FUNCTION();
 		pSourceVoice->Stop();
 	}
 
 	std::string BasicAudio::GetFileName() {
+		EG_PROFILE_FUNCTION();
 		return m_Path.filename().string();
 	}
 }

--- a/Engine/src/Engine/Core/Application.cpp
+++ b/Engine/src/Engine/Core/Application.cpp
@@ -46,7 +46,7 @@ namespace eg
 		EG_PROFILE_FUNCTION();
 		m_LayerStack.PushLayer(layer);
 	}
-	
+
 	void Application::PushOverlay(Layer *layer)
 	{
 		EG_PROFILE_FUNCTION();
@@ -59,7 +59,7 @@ namespace eg
 		EventDispatcher dispatcher(e);
 		dispatcher.Dispatch<WindowCloseEvent>(BIND_EVENT_FN(OnWindowClose));
 		dispatcher.Dispatch<WindowResizeEvent>(BIND_EVENT_FN(OnWindowResize));
-		
+
 
 		for (auto it = m_LayerStack.end(); it != m_LayerStack.begin();)
 		{
@@ -113,6 +113,7 @@ namespace eg
 
 	bool Application::OnWindowClose(WindowCloseEvent &e)
 	{
+		EG_PROFILE_FUNCTION();
 		m_Running = false;
 		return true;
 	}
@@ -132,12 +133,14 @@ namespace eg
 
 	void Application::SubmitToMainThread(std::function<void()> function)
 	{
+		EG_PROFILE_FUNCTION();
 		std::scoped_lock<std::mutex> lock(m_MainThreadQueueMutex);
 		m_MainThreadQueue.emplace_back(function);
 	}
 
 	void Application::ExecuteMainThreadQueue()
 	{
+		EG_PROFILE_FUNCTION();
 		std::scoped_lock<std::mutex> lock(m_MainThreadQueueMutex);
 
 		for (auto &function : m_MainThreadQueue)
@@ -147,16 +150,19 @@ namespace eg
 	}
 
 	void Application::SetRunning(bool val) {
+		EG_PROFILE_FUNCTION();
 		m_Running = val;
 	}
 
 	void Application::ChangeName(const char* text) {
+		EG_PROFILE_FUNCTION();
 		if (auto WinWindow = dynamic_cast<WindowsWindow*>(&this->GetWindow()))
 			glfwSetWindowTitle((WinWindow)->GetGLFWwindow(), text);
 
 	}
 
 	void Application::ChangeNameWithCurrentProject(bool saved) {
+		EG_PROFILE_FUNCTION();
 		std::string TitleText = "Muniffic editor [";
 		TitleText += Project::GetActive().get()->GetProjectName();
 		TitleText += "]";

--- a/Engine/src/Engine/Core/FileSystem.cpp
+++ b/Engine/src/Engine/Core/FileSystem.cpp
@@ -6,6 +6,7 @@ namespace eg {
 
 	Buffer FileSystem::ReadFileBinary(const std::filesystem::path& filepath)
 	{
+		EG_PROFILE_FUNCTION();
 		std::ifstream stream(filepath, std::ios::binary | std::ios::ate);
 
 		if (!stream)

--- a/Engine/src/Engine/Core/LayerStack.cpp
+++ b/Engine/src/Engine/Core/LayerStack.cpp
@@ -8,12 +8,14 @@ namespace eg {
 
 	LayerStack::~LayerStack()
 	{
+		EG_PROFILE_FUNCTION();
 		for (Layer* layer : m_Layers)
 			delete layer;
 	}
 
 	void LayerStack::PushLayer(Layer* layer)
 	{
+		EG_PROFILE_FUNCTION();
 		m_Layers.emplace(m_Layers.begin() + m_LayerInsertIndex, layer);
 		m_LayerInsertIndex++;
 		layer->OnAttach();
@@ -21,12 +23,14 @@ namespace eg {
 
 	void LayerStack::PushOverlay(Layer* overlay)
 	{
+		EG_PROFILE_FUNCTION();
 		m_Layers.emplace_back(overlay);
 		overlay->OnAttach();
 	}
 
 	void LayerStack::PopLayer(Layer* layer)
 	{
+		EG_PROFILE_FUNCTION();
 		auto it = std::find(m_Layers.begin(), m_Layers.end(), layer);
 		if (it != m_Layers.end())
 		{
@@ -37,6 +41,7 @@ namespace eg {
 
 	void LayerStack::PopOverlay(Layer* overlay)
 	{
+		EG_PROFILE_FUNCTION();
 		auto it = std::find(m_Layers.begin(), m_Layers.end(), overlay);
 		if (it != m_Layers.end())
 		{

--- a/Engine/src/Engine/Core/UUID.cpp
+++ b/Engine/src/Engine/Core/UUID.cpp
@@ -13,11 +13,13 @@ namespace eg{
 	UUID::UUID()
 		: m_UUID(s_UniformDistribution(s_Engine))
 	{
+		EG_PROFILE_FUNCTION();
 	}
 
 	UUID::UUID(int64_t uuid)
 		: m_UUID(uuid)
 	{
+		EG_PROFILE_FUNCTION();
 	}
 
 }

--- a/Engine/src/Engine/Core/Window.cpp
+++ b/Engine/src/Engine/Core/Window.cpp
@@ -9,6 +9,7 @@ namespace eg
 {
 	Scope<Window> Window::Create(const WindowProps& props)
 	{
+		EG_PROFILE_FUNCTION();
 #ifdef EG_PLATFORM_WINDOWS
 		return CreateScope<WindowsWindow>(props);
 #else

--- a/Engine/src/Engine/Imgui/ImguiLayer.cpp
+++ b/Engine/src/Engine/Imgui/ImguiLayer.cpp
@@ -16,11 +16,12 @@ namespace eg {
 	ImGuiLayer::ImGuiLayer()
 		:Layer("ImguiLayer"), m_Time(0.0f)
 	{
+		EG_PROFILE_FUNCTION();
 	}
 
     ImGuiLayer::~ImGuiLayer()
 	{
-
+		EG_PROFILE_FUNCTION();
 	}
 
     void ImGuiLayer::OnAttach()
@@ -42,9 +43,9 @@ namespace eg {
         	style.WindowRounding = 0.0f;
         	style.Colors[ImGuiCol_WindowBg].w = 1.0f;
         }
-        
+
         SetDarkThemeColors();
-        
+
         Application& app = Application::Get();
         GLFWwindow* window = static_cast<GLFWwindow*>(app.GetWindow().GetNativeWindow());
         ImGui_ImplGlfw_InitForOpenGL(window, true);
@@ -62,20 +63,21 @@ namespace eg {
     void ImGuiLayer::OnUpdate(Timestep ts)
     {
     }
-    
+
     void ImGuiLayer::OnImGuiRender()
     {
     }
-    
+
     void ImGuiLayer::OnEvent(Event& e)
     {
+		EG_PROFILE_FUNCTION();
     	if (m_BlockEvents) {
     		ImGuiIO& io = ImGui::GetIO();
     		e.Handled |= e.IsInCategory(EventCategoryMouse) & io.WantCaptureMouse;
     		e.Handled |= e.IsInCategory(EventCategoryKeyboard) & io.WantCaptureKeyboard;
     	}
     }
-    
+
     void ImGuiLayer::Begin()
     {
     	EG_PROFILE_FUNCTION();
@@ -84,7 +86,7 @@ namespace eg {
     	ImGui::NewFrame();
     	ImGuizmo::BeginFrame();
     }
-    
+
     void ImGuiLayer::End()
     {
     	EG_PROFILE_FUNCTION();
@@ -99,7 +101,7 @@ namespace eg {
     	glfwGetFramebufferSize(window, &display_w, &display_h);
     	glViewport(0, 0, display_w, display_h);
     	ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
-    
+
     	if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
     	{
     		GLFWwindow* backup_current_context = glfwGetCurrentContext();
@@ -108,43 +110,44 @@ namespace eg {
     		glfwMakeContextCurrent(backup_current_context);
     	}
     }
-    
+
     void ImGuiLayer::SetDarkThemeColors()
     {
     	auto& colors = ImGui::GetStyle().Colors;
     	colors[ImGuiCol_WindowBg] = ImVec4{ 0.1f, 0.105f, 0.11f, 1.0f };
-    
+
     	// Headers
     	colors[ImGuiCol_Header] = ImVec4{ 0.2f, 0.205f, 0.21f, 1.0f };
     	colors[ImGuiCol_HeaderHovered] = ImVec4{ 0.3f, 0.305f, 0.31f, 1.0f };
     	colors[ImGuiCol_HeaderActive] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
-    
+
     	// Buttons
     	colors[ImGuiCol_Button] = ImVec4{ 0.2f, 0.205f, 0.21f, 1.0f };
     	colors[ImGuiCol_ButtonHovered] = ImVec4{ 0.3f, 0.305f, 0.31f, 1.0f };
     	colors[ImGuiCol_ButtonActive] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
-    
+
     	// Frame BG
     	colors[ImGuiCol_FrameBg] = ImVec4{ 0.2f, 0.205f, 0.21f, 1.0f };
     	colors[ImGuiCol_FrameBgHovered] = ImVec4{ 0.3f, 0.305f, 0.31f, 1.0f };
     	colors[ImGuiCol_FrameBgActive] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
-    
+
     	// Tabs
     	colors[ImGuiCol_Tab] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
     	colors[ImGuiCol_TabHovered] = ImVec4{ 0.38f, 0.3805f, 0.381f, 1.0f };
     	colors[ImGuiCol_TabActive] = ImVec4{ 0.28f, 0.2805f, 0.281f, 1.0f };
     	colors[ImGuiCol_TabUnfocused] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
     	colors[ImGuiCol_TabUnfocusedActive] = ImVec4{ 0.2f, 0.205f, 0.21f, 1.0f };
-    
+
     	// Title
     	colors[ImGuiCol_TitleBg] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
     	colors[ImGuiCol_TitleBgActive] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
     	colors[ImGuiCol_TitleBgCollapsed] = ImVec4{ 0.15f, 0.1505f, 0.151f, 1.0f };
     }
-    
+
     uint32_t ImGuiLayer::GetActiveWidgetID() const
     {
+		EG_PROFILE_FUNCTION();
     	return GImGui->ActiveId;
     }
-    
+
 }

--- a/Engine/src/Engine/Math/Math.cpp
+++ b/Engine/src/Engine/Math/Math.cpp
@@ -9,6 +9,7 @@ namespace eg {
 	namespace Math {
 		bool DecomposeTransform(const glm::mat4& transform, glm::vec3& outTranslation, glm::vec3& outRotation, glm::vec3& outScale)
 		{
+		    EG_PROFILE_FUNCTION();
 			//From glm::decompose in matrix_decompose.inl
 			using namespace glm;
 			using T = float;

--- a/Engine/src/Engine/Physics/Physics2D.cpp
+++ b/Engine/src/Engine/Physics/Physics2D.cpp
@@ -3,10 +3,11 @@
 
 namespace eg
 {
-	namespace Utils 
+	namespace Utils
 	{
 		void RecreateFixture(const RigidBody2DComponent& rb, BoxCollider2DComponent& bc, const TransformComponent& transform)
 		{
+		    EG_PROFILE_FUNCTION();
 			b2Body* body = (b2Body*)rb.RuntimeBody;
 
 			if (!body)
@@ -42,6 +43,7 @@ namespace eg
 
 		void RecreateFixture(const RigidBody2DComponent& rb, CircleCollider2DComponent& cc, const TransformComponent& transform)
 		{
+		    EG_PROFILE_FUNCTION();
 			b2Body* body = (b2Body*)rb.RuntimeBody;
 
 			if (!body)

--- a/Engine/src/Engine/Project/Project.cpp
+++ b/Engine/src/Engine/Project/Project.cpp
@@ -7,10 +7,12 @@ namespace eg {
 	Project::Project(ProjectConfig projectConfig)
 		: m_Config(projectConfig)
 	{
+		EG_PROFILE_FUNCTION();
 	}
 
 	Ref<Project> Project::New()
 	{
+		EG_PROFILE_FUNCTION();
 		s_ActiveProject = CreateRef<Project>();
 
 		ConsolePanel::Log("File: Project.cpp - Project created successfully", ConsolePanel::LogType::Info);
@@ -19,6 +21,7 @@ namespace eg {
 
 	bool Project::Save(const std::filesystem::path& path)
 	{
+		EG_PROFILE_FUNCTION();
 		ProjectSerializer serializer(s_ActiveProject);
 		if (serializer.Serialize(path))
 		{
@@ -32,6 +35,7 @@ namespace eg {
 
 	Ref<Project> Project::Load(const std::filesystem::path& path)
 	{
+		EG_PROFILE_FUNCTION();
 		Ref<Project> project = CreateRef<Project>();
 		ProjectSerializer serializer(project);
 		if (serializer.Deserialize(path))

--- a/Engine/src/Engine/Project/ProjectSerializer.cpp
+++ b/Engine/src/Engine/Project/ProjectSerializer.cpp
@@ -10,10 +10,12 @@ namespace eg
 	ProjectSerializer::ProjectSerializer(Ref<Project> project)
 		: m_Project(project)
 	{
+		EG_PROFILE_FUNCTION();
 	}
 
 	bool ProjectSerializer::Serialize(const std::filesystem::path& path)
 	{
+		EG_PROFILE_FUNCTION();
 		const auto& config = m_Project->GetConfig();
 
 		YAML::Emitter out;
@@ -40,6 +42,7 @@ namespace eg
 
 	bool ProjectSerializer::Deserialize(const std::filesystem::path& path)
 	{
+		EG_PROFILE_FUNCTION();
 		auto& config = m_Project->GetConfig();
 		YAML::Node data;
 		try

--- a/Engine/src/Engine/Project/RecentProjectSerializer.cpp
+++ b/Engine/src/Engine/Project/RecentProjectSerializer.cpp
@@ -10,10 +10,12 @@ namespace eg
 {
 	RecentProjectSerializer::RecentProjectSerializer()
 	{
+		EG_PROFILE_FUNCTION();
 		Deserialize("recentProjectSerializer.txt");
 	}
 
 	void RecentProjectSerializer::DeleteProject(int id) {
+		EG_PROFILE_FUNCTION();
 		int cwel = m_ProjectList[id].find_last_of("\\");
 		std::string toDelete = m_ProjectList[id].erase(cwel);
 		std::filesystem::remove_all(toDelete);
@@ -23,6 +25,7 @@ namespace eg
 
 	bool RecentProjectSerializer::Serialize(const std::string& projectName, const std::string& path)
 	{
+		EG_PROFILE_FUNCTION();
 		bool present = false;
 		if (projectName != "")
 		{
@@ -70,11 +73,12 @@ namespace eg
 
 	bool RecentProjectSerializer::Deserialize(const std::string& path)
 	{
+		EG_PROFILE_FUNCTION();
 		YAML::Node data;
 		try
 		{
 			std::filesystem::path abs = std::filesystem::absolute(path);
-			
+
 			if (!std::filesystem::exists(abs))
 			{
 				//std::filesystem::create_(path);
@@ -121,5 +125,5 @@ namespace eg
 		ConsolePanel::Log("File: RecentProjectSerializer.cpp - Successfully loaded: " + path, ConsolePanel::LogType::Info);
 		return true;
 	}
-	
+
 }

--- a/Engine/src/Engine/Project/ScriptSerializer.cpp
+++ b/Engine/src/Engine/Project/ScriptSerializer.cpp
@@ -16,7 +16,7 @@ namespace eg
 		myfile << "local MunifficRootDir = \"../../../../\"\n";
 		myfile << "include(MunifficRootDir .. \"vendor/premake/premake_customization/solution_items.lua\")\n";
 		myfile << "workspace \""<<name<<"\"\n";
-		
+
 
 		myfile << "architecture \"x86_64\"\n";
 		myfile << "startproject \"Game\"\n";
@@ -82,5 +82,5 @@ namespace eg
 		return true;
 	}
 
-	
+
 }

--- a/Engine/src/Engine/Renderer/Animation.cpp
+++ b/Engine/src/Engine/Renderer/Animation.cpp
@@ -10,42 +10,50 @@ namespace eg
 	Animation::Animation()
 		: m_frameRate(1.0f), m_loop(true), m_playing(false), m_frame(0), m_AnimationID(UUID())
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	Animation::Animation(const std::string& path)
 		: m_frameRate(1.0f), m_loop(true), m_playing(false), m_frame(0), m_AnimationID(UUID())
 	{
+        EG_PROFILE_FUNCTION();
 		m_name = path;
 	}
 
 	Animation::Animation(const UUID&, const std::string& path)
 		: m_frameRate(1.0f), m_loop(true), m_playing(false), m_frame(0), m_AnimationID(UUID())
 	{
+        EG_PROFILE_FUNCTION();
 		m_name = path;
 	}
 
 	Animation::Animation(const std::vector<Ref<FrameData>>& frames, float frameRate, bool loop)
 		: m_frames(frames), m_frameRate(frameRate), m_loop(loop), m_playing(false), m_frame(0), m_AnimationID(UUID())
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	Animation::Animation(const UUID& id, const std::vector<Ref<FrameData>>& frames, float frameRate, bool loop)
 		: m_frames(frames), m_frameRate(frameRate), m_loop(loop), m_playing(false), m_frame(0), m_AnimationID(id)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	Ref<Animation> Animation::Create(const std::string& path)
 	{
+        EG_PROFILE_FUNCTION();
 		return CreateRef<Animation>(path);
 	}
 
 	Ref<Animation> Animation::Create(const std::vector<Ref<FrameData>>& frames, float frameRate, bool loop)
 	{
+        EG_PROFILE_FUNCTION();
 		return CreateRef<Animation>(frames, frameRate, loop);
 	}
 
 	Ref<Animation> Animation::Create(const UUID& id)
 	{
+        EG_PROFILE_FUNCTION();
 		EG_PROFILE_FUNCTION();
 		if (!ResourceDatabase::FindResourceData(id, ResourceType::Animation))
 			return nullptr;
@@ -69,7 +77,7 @@ namespace eg
 
 	void Animation::Update(float dt, float speed)
 	{
-		EG_PROFILE_FUNCTION();
+        EG_PROFILE_FUNCTION();
 		if (m_playing && m_frames.size() > 0)
 		{
 			m_AnimationEnded = false;
@@ -97,33 +105,39 @@ namespace eg
 
 	void Animation::Play()
 	{
+		EG_PROFILE_FUNCTION();
 		m_playing = true;
 	}
 
 	void Animation::Pause()
 	{
+		EG_PROFILE_FUNCTION();
 		m_playing = false;
 	}
 
 	void Animation::Start()
 	{
+		EG_PROFILE_FUNCTION();
 		m_playing = true;
 		m_frame = 0;
 	}
 
 	void Animation::Stop()
 	{
+		EG_PROFILE_FUNCTION();
 		m_playing = false;
 		m_frame = 0;
 	}
 
 	void Animation::SetLoop(bool loop)
 	{
+		EG_PROFILE_FUNCTION();
 		m_loop = loop;
 	}
 
 	void Animation::SetFrame(int frame)
 	{
+		EG_PROFILE_FUNCTION();
 		m_frame = frame;
 		if (m_frame >= m_frames.size())
 			m_frame = m_frames.size() - 1;
@@ -133,21 +147,25 @@ namespace eg
 
 	void Animation::SetFrameRate(float frameRate)
 	{
+		EG_PROFILE_FUNCTION();
 		m_frameRate = frameRate;
 	}
 
 	void Animation::SetName(const std::string& name)
 	{
+		EG_PROFILE_FUNCTION();
 		m_name = name;
 	}
 
 	void Animation::SetID(const UUID& id)
 	{
+		EG_PROFILE_FUNCTION();
 		m_AnimationID = id;
 	}
 
 	void Animation::SetEntityID(const UUID& id)
 	{
+		EG_PROFILE_FUNCTION();
 		m_EntityID = id;
 		for (auto& frame : m_frames)
 		{
@@ -225,7 +243,7 @@ namespace eg
 			duration += frame->GetFrameDuration();
 		}
 		return duration;
-	
+
 	}
 
 	const Ref<FrameData> Animation::GetFrame(int frame) const
@@ -244,13 +262,14 @@ namespace eg
 
 	Ref<FrameData> FrameData::Create()
 	{
+		EG_PROFILE_FUNCTION();
 		return CreateRef<FrameData>();
 	}
 
 	Ref<FrameData> FrameData::Create(const UUID& id)
 	{
 		EG_PROFILE_FUNCTION();
-		
+
 		Ref<FrameData> frame = CreateRef<FrameData>();
 
 		FrameResourceData* frameData = (FrameResourceData*)ResourceDatabase::GetResourceData(id);
@@ -260,10 +279,10 @@ namespace eg
 		frame->ClassName = frameData->ClassName;
 		frame->FunctionCallName = frameData->FunctionCallName;
 		frame->SubTexture = SubTexture2D::Create(frameData->SubTexture);
-		
+
 
 		return frame;
-	
+
 	}
 
 	Ref<FrameData> FrameData::Create(const UUID& id, const Ref<SubTexture2D>& subTexture, int frameDuration, bool isKeyFrame, const std::string& className, const std::string& functionCallName)
@@ -283,16 +302,19 @@ namespace eg
 	FrameData::FrameData()
 		: FrameDuration(1), isKeyFrame(false), ClassName(""), FunctionCallName("")
 	{
+		EG_PROFILE_FUNCTION();
 	}
 
 	FrameData::FrameData(const UUID& id)
 		: FrameID(id)
 	{
+		EG_PROFILE_FUNCTION();
 	}
 
 	FrameData::FrameData(const UUID& id, const Ref<SubTexture2D>& subTexture, int frameDuration, bool isKeyFrame, const std::string& className, const std::string& functionCallName)
 		: FrameID(id), FrameDuration(frameDuration), isKeyFrame(isKeyFrame), ClassName(className), FunctionCallName(functionCallName), SubTexture(subTexture)
 	{
+		EG_PROFILE_FUNCTION();
 	}
 
 	void FrameData::Save()

--- a/Engine/src/Engine/Renderer/Animator.cpp
+++ b/Engine/src/Engine/Renderer/Animator.cpp
@@ -2,10 +2,11 @@
 #include "Animator.h"
 
 namespace eg {
-		
+
 	Animator::Animator()
 		: m_AnimationIndex(0), m_Speed(1.0f)
 	{
+        EG_PROFILE_FUNCTION();
 		m_Animations = CreateRef<std::vector<Ref<Animation>>>();
 		m_Transitions = CreateRef<std::vector<std::pair<size_t, size_t>>>();
 	}
@@ -13,6 +14,7 @@ namespace eg {
 	Animator::Animator(Ref<std::vector<Ref<Animation>>> animations, float speed, UUID entityID)
 		:m_AnimationIndex(0), m_Animations(animations), m_Speed(speed), m_EntityID(entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		for(Ref<Animation> anim : *m_Animations)
 			anim->SetEntityID(m_EntityID);
 	}
@@ -67,7 +69,7 @@ namespace eg {
 		int index = GetAnimationIndex(animationName);
 		if (index >= 0)
 			ChangeAnimation(index);
-	
+
 	}
 
 	void Animator::SetAnimations(Ref<std::vector<Ref<Animation>>> animations)

--- a/Engine/src/Engine/Renderer/Buffer.cpp
+++ b/Engine/src/Engine/Renderer/Buffer.cpp
@@ -9,6 +9,7 @@
 namespace eg {
 	Ref<IndexBuffer> IndexBuffer::Create(uint32_t* indices, uint32_t count)
 	{
+        EG_PROFILE_FUNCTION();
 		switch (Renderer::GetAPI())
 		{
 		case RendererAPI::API::None:
@@ -26,6 +27,7 @@ namespace eg {
 
 	Ref<VertexBuffer>(VertexBuffer::Create(uint32_t size))
 	{
+        EG_PROFILE_FUNCTION();
 		switch (Renderer::GetAPI())
 		{
 		case RendererAPI::API::None:
@@ -43,6 +45,7 @@ namespace eg {
 
 	Ref<VertexBuffer> VertexBuffer::Create(float* vertices, uint32_t size)
 	{
+        EG_PROFILE_FUNCTION();
 		switch (Renderer::GetAPI())
 		{
 		case RendererAPI::API::None:

--- a/Engine/src/Engine/Renderer/EditorCamera.cpp
+++ b/Engine/src/Engine/Renderer/EditorCamera.cpp
@@ -10,17 +10,20 @@ namespace eg {
 	EditorCamera::EditorCamera(float fov, float aspectRatio, float nearClip, float farClip)
 		: m_FOV(fov), m_AspectRatio(aspectRatio), m_NearClip(nearClip), m_FarClip(farClip), Camera(glm::perspective(glm::radians(fov), aspectRatio, nearClip, farClip))
 	{
+        EG_PROFILE_FUNCTION();
 		UpdateView();
 	}
 
 	void EditorCamera::UpdateProjection()
 	{
+        EG_PROFILE_FUNCTION();
 		m_AspectRatio = m_ViewportWidth / m_ViewportHeight;
 		m_ProjectionMatrix = glm::perspective(glm::radians(m_FOV), m_AspectRatio, m_NearClip, m_FarClip);
 	}
 
 	void EditorCamera::UpdateView()
 	{
+        EG_PROFILE_FUNCTION();
 		m_Position = CalculatePosition();
 
 		glm::quat orientation = GetOrientation();
@@ -30,6 +33,7 @@ namespace eg {
 
 	std::pair<float, float> EditorCamera::PanSpeed() const
 	{
+        EG_PROFILE_FUNCTION();
 		float x = std::min(m_ViewportWidth / 1000.0f, 2.4f); // max = 2.4f
 		float xFactor = 0.0366f * (x * x) - 0.1778f * x + 0.3021f;
 
@@ -41,10 +45,12 @@ namespace eg {
 
 	float EditorCamera::RotationSpeed() const
 	{
+        EG_PROFILE_FUNCTION();
 		return 0.8f;
 	}
 
 	float EditorCamera::ZoomSpeed() const {
+        EG_PROFILE_FUNCTION();
 		float distance = m_Distance * 0.2f;
 		distance = std::max(distance, 0.0f);
 		float speed = distance * distance;
@@ -54,6 +60,7 @@ namespace eg {
 
 	void EditorCamera::OnUpdate(Timestep ts)
 	{
+        EG_PROFILE_FUNCTION();
 		if (Input::IsKeyPressed(Key::LeftAlt)) {
 			const glm::vec2& mouse{ Input::GetCursorPositonX(), Input::GetCursorPositonY() };
 			glm::vec2 delta = (mouse - m_InitialMousePosition) * 0.003f;
@@ -72,12 +79,14 @@ namespace eg {
 
 	void EditorCamera::OnEvent(Event& e)
 	{
+        EG_PROFILE_FUNCTION();
 		EventDispatcher dispatcher(e);
 		dispatcher.Dispatch<MouseScrolledEvent>(BIND_EVENT_FN(EditorCamera::OnMouseScrolled));
 	}
 
 	bool EditorCamera::OnMouseScrolled(MouseScrolledEvent& e)
 	{
+        EG_PROFILE_FUNCTION();
 		float delta = e.GetYOffset() * 0.1f;
 		MouseZoom(delta);
 		UpdateView();
@@ -86,6 +95,7 @@ namespace eg {
 
 	void EditorCamera::MousePan(const glm::vec2& delta)
 	{
+        EG_PROFILE_FUNCTION();
 		auto [xSpeed, ySpeed] = PanSpeed();
 		m_FocalPoint += -GetRightDirection() * delta.x * xSpeed * m_Distance;
 		m_FocalPoint += GetUpDirection() * delta.y * ySpeed * m_Distance;
@@ -93,6 +103,7 @@ namespace eg {
 
 	void EditorCamera::MouseRotate(const glm::vec2& delta)
 	{
+        EG_PROFILE_FUNCTION();
 		float yawSign = GetUpDirection().y < 0 ? -1.0f : 1.0f;
 		m_Yaw += yawSign * delta.x * RotationSpeed();
 		m_Pitch += delta.y * RotationSpeed();
@@ -100,6 +111,7 @@ namespace eg {
 
 	void EditorCamera::MouseZoom(float delta)
 	{
+        EG_PROFILE_FUNCTION();
 		m_Distance -= delta * ZoomSpeed();
 		if (m_Distance < 1.0f) {
 			m_FocalPoint += GetForwardDirection();
@@ -109,26 +121,31 @@ namespace eg {
 
 	glm::vec3 EditorCamera::GetUpDirection() const
 	{
+        EG_PROFILE_FUNCTION();
 		return glm::rotate(GetOrientation(), glm::vec3(0.0f, 1.0f, 0.0f));
 	}
 
 	glm::vec3 EditorCamera::GetRightDirection() const
 	{
+        EG_PROFILE_FUNCTION();
 		return glm::rotate(GetOrientation(), glm::vec3(1.0f, 0.0f, 0.0f));
 	}
 
 	glm::vec3 EditorCamera::GetForwardDirection() const
 	{
+        EG_PROFILE_FUNCTION();
 		return glm::rotate(GetOrientation(), glm::vec3(0.0f, 0.0f, -1.0f));
 	}
 
 	glm::quat EditorCamera::GetOrientation() const
 	{
+        EG_PROFILE_FUNCTION();
 		return glm::quat(glm::vec3(-m_Pitch, -m_Yaw, 0.0f));
 	}
 
 	glm::vec3 EditorCamera::CalculatePosition() const
 	{
+        EG_PROFILE_FUNCTION();
 		return m_FocalPoint - GetForwardDirection() * m_Distance;
 	}
 

--- a/Engine/src/Engine/Renderer/Font.cpp
+++ b/Engine/src/Engine/Renderer/Font.cpp
@@ -16,20 +16,25 @@
 namespace eg
 {
 	Font::Font(MSDFData* data, Ref<Texture2D> atlasTexture)
-		: m_Data(data), m_AtlasTexture(atlasTexture) {}
+		: m_Data(data), m_AtlasTexture(atlasTexture) {
+        EG_PROFILE_FUNCTION();
+        }
 
 	Font::Font(Font* font)
-		: m_Data(font->m_Data), m_AtlasTexture(font->m_AtlasTexture) {}
+		: m_Data(font->m_Data), m_AtlasTexture(font->m_AtlasTexture) {
+        EG_PROFILE_FUNCTION();
+        }
 
 	Font::~Font()
 	{
-		//delete m_Data;
+        EG_PROFILE_FUNCTION();
 	}
 
 	UUID Font::s_DefaultFontUUID;
 
 	void Font::LoadFont(const std::filesystem::path& path)
 	{
+        EG_PROFILE_FUNCTION();
 		FontResourceData* data = new FontResourceData();
 		data->ParentDirectory = AssetDirectoryManager::GetRootAssetTypeDirectory(ResourceType::Font);
 		data->ResourceName = path.stem().string();

--- a/Engine/src/Engine/Renderer/FrambeBuffer.cpp
+++ b/Engine/src/Engine/Renderer/FrambeBuffer.cpp
@@ -7,9 +7,10 @@
 namespace eg {
 	Ref<FrameBuffer> FrameBuffer::Create(const FrameBufferSpecification& spec)
 	{
+        EG_PROFILE_FUNCTION();
 		switch (Renderer::GetAPI())
 		{
-		case RendererAPI::API::None: 
+		case RendererAPI::API::None:
 			ConsolePanel::Log("File: FrameBuffer.cpp - RendererAPI::None is currently not supported!", ConsolePanel::LogType::Error);
 			EG_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
 		case RendererAPI::API::OpenGL:

--- a/Engine/src/Engine/Renderer/OrthographicCameraController.cpp
+++ b/Engine/src/Engine/Renderer/OrthographicCameraController.cpp
@@ -9,12 +9,12 @@
 namespace eg {
 
 	OrthographicCameraController::OrthographicCameraController(float aspectRatio, bool rotation)
-		: m_AspectRatio(aspectRatio), m_Bounds({ -m_AspectRatio * m_ZoomLevel, m_AspectRatio * m_ZoomLevel, -m_ZoomLevel, m_ZoomLevel }), 
+		: m_AspectRatio(aspectRatio), m_Bounds({ -m_AspectRatio * m_ZoomLevel, m_AspectRatio * m_ZoomLevel, -m_ZoomLevel, m_ZoomLevel }),
 		m_Camera(m_Bounds.Left, m_Bounds.Right, m_Bounds.Bottom, m_Bounds.Top), m_Rotation(rotation)
 	{
 	}
 
-	
+
 
 	void OrthographicCameraController::OnUpdate(Timestep ts)
 	{
@@ -39,7 +39,7 @@ namespace eg {
 			m_CameraPosition.x -= -sin(glm::radians(m_CameraRotation)) * m_CameraSpeed * (float)ts * m_ZoomLevel;
 			m_CameraPosition.y -= cos(glm::radians(m_CameraRotation)) * m_CameraSpeed * (float)ts * m_ZoomLevel;
 		}
-		
+
 		if (m_Rotation) {
 			if (eg::Input::IsKeyPressed(KeyCode::Q))
 				m_CameraRotation += m_CameraRotationSpeed * (float)ts;
@@ -55,7 +55,7 @@ namespace eg {
 		}
 
 		m_Camera.SetPosition(m_CameraPosition);
-		
+
 	}
 
 	void OrthographicCameraController::OnEvent(Event& e)
@@ -68,12 +68,14 @@ namespace eg {
 
 	void OrthographicCameraController::OnResize(float width, float height)
 	{
+        EG_PROFILE_FUNCTION();
 		m_AspectRatio = width / height;
 		RecalculateView();
 	}
 
 	void OrthographicCameraController::RecalculateView()
 	{
+        EG_PROFILE_FUNCTION();
 		m_Bounds = { -m_AspectRatio * m_ZoomLevel, m_AspectRatio * m_ZoomLevel, -m_ZoomLevel, m_ZoomLevel };
 		m_Camera.SetProjection(m_Bounds.Left, m_Bounds.Right, m_Bounds.Bottom, m_Bounds.Top);
 	}
@@ -86,7 +88,7 @@ namespace eg {
 		else
 			m_ZoomLevel *= m_ZoomChange;
 
-		
+
 		RecalculateView();
 		return false;
 	}
@@ -94,10 +96,10 @@ namespace eg {
 	bool OrthographicCameraController::OnWindowResized(WindowResizeEvent& e)
 	{
 		EG_PROFILE_FUNCTION();
-		
+
 		OnResize((float)e.GetWidth(), (float)e.GetHeight());
 		return false;
 	}
 
-	
+
 }

--- a/Engine/src/Engine/Renderer/Renderer.cpp
+++ b/Engine/src/Engine/Renderer/Renderer.cpp
@@ -17,27 +17,32 @@ namespace eg {
 
 	void Renderer::Shutdown()
 	{
+        EG_PROFILE_FUNCTION();
 		ConsolePanel::Log("File: Renderer.cpp - Renderer Shutdown", ConsolePanel::LogType::Info);
 		Renderer2D::Shutdown();
 	}
 
 	void Renderer::OnWindowResize(uint32_t width, uint32_t height)
 	{
+        EG_PROFILE_FUNCTION();
 		RenderCommand::SetViewPort(0, 0, width, height);
 	}
 
 	void Renderer::BeginScene(OrthographicCamera& camera)
 	{
+        EG_PROFILE_FUNCTION();
 		m_SceneData->ViewProjectionMatrix = camera.GetViewProjection();
 
 	}
 
 	void Renderer::EndScene()
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	void Renderer::Submit(const Ref<Shader>& shader,const Ref<VertexArray>& vertexArray, const glm::mat4& transform)
 	{
+        EG_PROFILE_FUNCTION();
 		shader->Bind();
 		std::dynamic_pointer_cast<OpenGLShader>(shader)->UploadUniformMat4("u_ViewProjection", m_SceneData->ViewProjectionMatrix);
 		std::dynamic_pointer_cast<OpenGLShader>(shader)->UploadUniformMat4("u_Transform", transform);

--- a/Engine/src/Engine/Renderer/Renderer2D.cpp
+++ b/Engine/src/Engine/Renderer/Renderer2D.cpp
@@ -102,7 +102,7 @@ namespace eg {
 		Ref<Texture2D> FontAtlasTexture;
 
 		glm::vec4 QuadVertexPositions[4];
-		
+
 		Renderer2D::Statistics Stats;
 
 		struct CameraData
@@ -111,11 +111,11 @@ namespace eg {
 		};
 		CameraData CameraBuffer;
 		Ref<UniformBuffer> CameraUniformBuffer;
-	};	
+	};
 
 	static Renderer2DData s_Data;
 
-	
+
 
 	void Renderer2D::Init() {
 		EG_PROFILE_FUNCTION();
@@ -213,7 +213,7 @@ namespace eg {
 		s_Data.TextShader = Shader::Create("assets/shaders/Renderer2D_Text.glsl");
 
 		s_Data.TextureSlots[0] = s_Data.WhiteTexture;
-		
+
 		s_Data.QuadVertexPositions[0] = { -0.5f, -0.5f, 0.0f, 1.0f };
 		s_Data.QuadVertexPositions[1] = { 0.5f, -0.5f, 0.0f, 1.0f };
 		s_Data.QuadVertexPositions[2] = { 0.5f, 0.5f, 0.0f, 1.0f };
@@ -242,7 +242,7 @@ namespace eg {
 	void Renderer2D::BeginScene(const EditorCamera& camera)
 	{
 		EG_PROFILE_FUNCTION();
-		
+
 		s_Data.CameraBuffer.ViewProjection = camera.GetViewProjection();
 		s_Data.CameraUniformBuffer->SetData(&s_Data.CameraBuffer, sizeof(Renderer2DData::CameraData));
 		StartBatch();
@@ -288,7 +288,7 @@ namespace eg {
 			s_Data.CircleShader->Bind();
 			RenderCommand::DrawIndexed(s_Data.CircleVertexArray, s_Data.CircleIndexCount);
 			s_Data.Stats.DrawCalls++;
-		
+
 		}
 
 		if (s_Data.LineVertexCount)
@@ -300,7 +300,7 @@ namespace eg {
 			RenderCommand::SetLineThickness(s_Data.LineThickness);
 			RenderCommand::DrawLines(s_Data.LineVertexArray, s_Data.LineVertexCount);
 			s_Data.Stats.DrawCalls++;
-		
+
 		}
 
 		if (s_Data.TextIndexCount)
@@ -318,6 +318,7 @@ namespace eg {
 
 	void Renderer2D::StartBatch()
 	{
+        EG_PROFILE_FUNCTION();
 		s_Data.QuadIndexCount = 0;
 		s_Data.QuadVertexBufferPtr = s_Data.QuadVertexBufferBase;
 
@@ -340,6 +341,7 @@ namespace eg {
 	}
 
 	void Renderer2D::DrawQuad(const glm::vec2& position, const glm::vec2& size, const glm::vec4& color) {
+        EG_PROFILE_FUNCTION();
 		DrawQuad({ position.x, position.y, 0.0f }, size, color);
 	}
 
@@ -349,7 +351,7 @@ namespace eg {
 		constexpr size_t quadVertexCount = 4;
 		const glm::vec2 textureCoords[] = { {0.0f,0.0f}, {1.0f,0.0f}, {1.0f,1.0f}, {0.0f,1.0f} };
 
-		if (s_Data.QuadIndexCount >= Renderer2DData::MaxIndices) 
+		if (s_Data.QuadIndexCount >= Renderer2DData::MaxIndices)
 			FlushAndReset();
 
 		const float texIndex = 0.0f; // White Texture
@@ -374,6 +376,7 @@ namespace eg {
 	}
 
 	void Renderer2D::DrawQuad(const glm::vec2& position, const glm::vec2& size, const Ref<Texture2D>& texture, float tilingFactor, const glm::vec4& tintColor) {
+        EG_PROFILE_FUNCTION();
 		DrawQuad({ position.x, position.y, 0.0f }, size, texture, tilingFactor, tintColor);
 	}
 
@@ -386,6 +389,7 @@ namespace eg {
 	}
 
 	void Renderer2D::DrawQuad(const glm::vec2& position, const glm::vec2& size, const Ref<SubTexture2D>& subTexture, float tilingFactor, const glm::vec4& tintColor) {
+        EG_PROFILE_FUNCTION();
 		DrawQuad({ position.x, position.y, 0.0f }, size, subTexture, tilingFactor, tintColor);
 	}
 
@@ -511,6 +515,7 @@ namespace eg {
 	}
 
 	void Renderer2D::DrawRotatedQuad(const glm::vec2& position, const glm::vec2& size, float rotation, const glm::vec4& color) {
+        EG_PROFILE_FUNCTION();
 		DrawRotatedQuad({ position.x, position.y, 0.0f }, size, rotation, color);
 	}
 
@@ -546,6 +551,7 @@ namespace eg {
 	}
 
 	void Renderer2D::DrawRotatedQuad(const glm::vec2& position, const glm::vec2& size, float rotation, const Ref<Texture2D>& texture, float tilingFactor, const glm::vec4& tintColor) {
+        EG_PROFILE_FUNCTION();
 		DrawRotatedQuad({ position.x, position.y, 0.0f }, size, rotation, texture, tilingFactor, tintColor);
 	}
 
@@ -595,10 +601,12 @@ namespace eg {
 	}
 
 	void Renderer2D::DrawRotatedQuad(const glm::vec2& position, const glm::vec2& size, float rotation, const Ref<SubTexture2D>& subTexture, float tilingFactor, const glm::vec4& tintColor) {
+        EG_PROFILE_FUNCTION();
 		DrawRotatedQuad({ position.x, position.y, 0.0f }, size, rotation, subTexture, tilingFactor, tintColor);
 	}
 
 	void Renderer2D::DrawRotatedQuad(const glm::vec3& position, const glm::vec2& size, float rotation, const Ref<SubTexture2D>& subTexture, float tilingFactor, const glm::vec4& tintColor) {
+        EG_PROFILE_FUNCTION();
 		constexpr size_t quadVertexCount = 4;
 		const glm::vec4 color = { 1.0f,1.0f,1.0f,1.0f };
 		const glm::vec2* textureCoords = subTexture->GetTexCoords();
@@ -673,6 +681,7 @@ namespace eg {
 
 	void Renderer2D::DrawLine(const glm::vec3& start, const glm::vec3& end, const glm::vec4& color, int entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		if(s_Data.LineVertexCount >= Renderer2DData::MaxVertices)
 			FlushAndReset();
 		s_Data.LineVertexBufferPtr->Position = start;
@@ -690,6 +699,7 @@ namespace eg {
 
 	void Renderer2D::DrawRect(const glm::vec3& position, const glm::vec2& size, const glm::vec4& color, int entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		glm::vec3 p0 = glm::vec3(position.x - size.x * 0.5f, position.y - size.y * 0.5f, position.z);
 		glm::vec3 p1 = glm::vec3(position.x + size.x * 0.5f, position.y - size.y * 0.5f, position.z);
 		glm::vec3 p2 = glm::vec3(position.x + size.x * 0.5f, position.y + size.y * 0.5f, position.z);
@@ -703,6 +713,7 @@ namespace eg {
 
 	void Renderer2D::DrawRect(const glm::mat4& transform, const glm::vec4& color, int entityID)
 	{
+        EG_PROFILE_FUNCTION();
 
 		glm::vec3 lineVertices[4];
 		for (size_t i = 0; i < 4; i++)
@@ -718,6 +729,7 @@ namespace eg {
 
 	void Renderer2D::DrawString(const std::string& text, Ref<Font> font, const glm::mat4& transform, const TextParams& textParams, int entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		const auto& fontGeometry = font->GetData()->FontGeometry;
 		const auto& metrics = fontGeometry.getMetrics();
 		Ref<Texture2D> atlas = font->GetAtlasTexture();
@@ -827,21 +839,25 @@ namespace eg {
 
 	void Renderer2D::DrawString(const std::string& string, const glm::mat4& transform, const TextComponent& component, int entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		DrawString(string, component.RuntimeFont, transform, { component.Color, component.Kerning, component.LineSpacing }, entityID);
 	}
 
 	float Renderer2D::GetLineThickness()
 	{
+        EG_PROFILE_FUNCTION();
 		return s_Data.LineThickness;
 	}
 
 	void Renderer2D::SetLineThickness(float thickness)
 	{
+        EG_PROFILE_FUNCTION();
 		s_Data.LineThickness = thickness;
 	}
 
 	void Renderer2D::DrawSprite(const glm::mat4& transform, SpriteRendererComponent& src, int entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		if(src.Texture)
 			DrawQuad(transform, src.Texture, src.TilingFactor, src.Color, entityID);
 		else
@@ -850,6 +866,7 @@ namespace eg {
 
 	void Renderer2D::DrawSprite(const glm::mat4& transform, SpriteRendererSTComponent& src, int entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		if(src.SubTexture->GetTexture())
 			DrawQuad(transform, src.SubTexture, src.TilingFactor, src.Color, entityID);
 		else
@@ -857,10 +874,12 @@ namespace eg {
 	}
 
 	void Renderer2D::ResetStats() {
+        EG_PROFILE_FUNCTION();
 		memset(&s_Data.Stats, 0, sizeof(Statistics));
 	}
 
 	Renderer2D::Statistics Renderer2D::GetStats() {
+        EG_PROFILE_FUNCTION();
 		return s_Data.Stats;
 	}
 }

--- a/Engine/src/Engine/Renderer/Shader.cpp
+++ b/Engine/src/Engine/Renderer/Shader.cpp
@@ -8,9 +8,10 @@
 namespace eg {
 	Ref<Shader> Shader::Create(const std::string& vertexSrc, const std::string& fragmentSrc, const std::string& name)
 	{
+        EG_PROFILE_FUNCTION();
 		switch (Renderer::GetAPI())
 		{
-			case RendererAPI::API::None: 
+			case RendererAPI::API::None:
 				EG_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
 				ConsolePanel::Log("File: Shader.cpp - RendererAPI::None is currently not supported!", ConsolePanel::LogType::Error);
 				return nullptr;
@@ -26,13 +27,14 @@ namespace eg {
 
 	Ref<Shader> Shader::Create(const std::string& filepath)
 	{
+        EG_PROFILE_FUNCTION();
 		switch (Renderer::GetAPI())
 		{
-		case RendererAPI::API::None: 
-			EG_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); 
+		case RendererAPI::API::None:
+			EG_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
 			ConsolePanel::Log("File: Shader.cpp - RendererAPI::None is currently not supported!", ConsolePanel::LogType::Error);
 			return nullptr;
-		case RendererAPI::API::OpenGL: 
+		case RendererAPI::API::OpenGL:
 			ConsolePanel::Log("File: Shader.cpp - Successfully Created Shader", ConsolePanel::LogType::Info);
 			return  std::make_shared<OpenGLShader>(filepath);
 		}
@@ -44,6 +46,7 @@ namespace eg {
 
 	void ShaderLibrary::Add(const Ref<Shader>& shader)
 	{
+        EG_PROFILE_FUNCTION();
 		auto& name = shader->GetName();
 		EG_CORE_ASSERT(!Exists(name), "Shader already exists!");
 		ConsolePanel::Log("File: Shader.cpp - Shader already exists!", ConsolePanel::LogType::Warning);
@@ -52,6 +55,7 @@ namespace eg {
 
 	void ShaderLibrary::Add(const std::string& name, const Ref<Shader>& shader)
 	{
+        EG_PROFILE_FUNCTION();
 		EG_CORE_ASSERT(!Exists(name), "Shader already exists!");
 		ConsolePanel::Log("File: Shader.cpp - Shader already exists!", ConsolePanel::LogType::Warning);
 		m_Shaders[name] = shader;
@@ -59,6 +63,7 @@ namespace eg {
 
 	Ref<Shader> ShaderLibrary::Load(const std::string& filepath)
 	{
+        EG_PROFILE_FUNCTION();
 		auto shader = Shader::Create(filepath);
 		Add(shader);
 		return shader;
@@ -66,6 +71,7 @@ namespace eg {
 
 	Ref<Shader> ShaderLibrary::Load(const std::string& name, const std::string& filepath)
 	{
+        EG_PROFILE_FUNCTION();
 		auto shader = Shader::Create(filepath);
 		Add(name, shader);
 		return shader;
@@ -73,6 +79,7 @@ namespace eg {
 
 	Ref<Shader> ShaderLibrary::Load(const std::string& vertexFilepath, const std::string& fragmentFilepath, const std::string& name)
 	{
+        EG_PROFILE_FUNCTION();
 		auto shader = Shader::Create(vertexFilepath, fragmentFilepath, name);
 		Add(name, shader);
 		return shader;
@@ -80,6 +87,7 @@ namespace eg {
 
 	Ref<Shader> ShaderLibrary::Get(const std::string& name)
 	{
+        EG_PROFILE_FUNCTION();
 		EG_CORE_ASSERT(Exists(name), "Shader not found!");
 		ConsolePanel::Log("File: Shader.cpp - Shader do not exist!", ConsolePanel::LogType::Error);
 		return m_Shaders[name];
@@ -87,6 +95,7 @@ namespace eg {
 
 	bool ShaderLibrary::Exists(const std::string& name) const
 	{
+        EG_PROFILE_FUNCTION();
 		return m_Shaders.find(name) != m_Shaders.end();
 	}
 }

--- a/Engine/src/Engine/Renderer/SubTexture2D.cpp
+++ b/Engine/src/Engine/Renderer/SubTexture2D.cpp
@@ -7,6 +7,7 @@ namespace eg
 	SubTexture2D::SubTexture2D(const Ref<Texture2D> &texture, const glm::vec2 &min, const glm::vec2 &max)
 		: m_Texture(texture)
 	{
+        EG_PROFILE_FUNCTION();
 		m_TexCoords[0] = {min.x, min.y};
 		m_TexCoords[1] = {max.x, min.y};
 		m_TexCoords[2] = {max.x, max.y};
@@ -15,6 +16,7 @@ namespace eg
 
 	Ref<SubTexture2D> SubTexture2D::Create(const Ref<Texture2D> &texture, const glm::vec2 &min, const glm::vec2 &max)
 	{
+        EG_PROFILE_FUNCTION();
 		return CreateRef<SubTexture2D>(texture, min, max);
 	}
 
@@ -41,6 +43,7 @@ namespace eg
 
 	Ref<SubTexture2D> SubTexture2D::CreateFromCoords(const Ref<Texture2D> &texture, const glm::vec2 &coords, const glm::vec2 &cellSize, const glm::vec2 &spriteSize /*= { 1, 1 }*/)
 	{
+        EG_PROFILE_FUNCTION();
 
 		glm::vec2 min = {(coords.x * cellSize.x) / texture->GetWidth(), (coords.y * cellSize.y) / texture->GetHeight()};
 		glm::vec2 max = {((coords.x + spriteSize.x) * cellSize.x) / texture->GetWidth(), ((coords.y + spriteSize.y) * cellSize.y) / texture->GetHeight()};

--- a/Engine/src/Engine/Renderer/Texture.cpp
+++ b/Engine/src/Engine/Renderer/Texture.cpp
@@ -7,6 +7,7 @@
 namespace eg {
 	Ref<Texture2D> Texture2D::Create(const std::string& path)
 	{
+        EG_PROFILE_FUNCTION();
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None: EG_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
@@ -19,6 +20,7 @@ namespace eg {
 
 	Ref<Texture2D> Texture2D::Create(const UUID& id)
 	{
+        EG_PROFILE_FUNCTION();
 		switch (Renderer::GetAPI())
 		{
 		case RendererAPI::API::None: EG_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
@@ -27,15 +29,16 @@ namespace eg {
 
 		EG_ASSERT(false, "Unknown RendererAPI!");
 		return nullptr;
-	
+
 	}
 
 	Ref<Texture2D> Texture2D::Create(const TextureSpecification& specification)
 	{
+        EG_PROFILE_FUNCTION();
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None: EG_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL: 
+			case RendererAPI::API::OpenGL:
 				ConsolePanel::Log("File: Texture.cpp - 2D Texture Created", ConsolePanel::LogType::Info);
 				return OpenGLTexture2D::Create(specification);
 		}

--- a/Engine/src/Engine/Renderer/UniformBuffer.cpp
+++ b/Engine/src/Engine/Renderer/UniformBuffer.cpp
@@ -8,13 +8,14 @@
 namespace eg {
 	Ref<UniformBuffer> UniformBuffer::Create(uint32_t size, uint32_t binding)
 	{
+        EG_PROFILE_FUNCTION();
 		switch (Renderer::GetAPI())
 		{
-		case RendererAPI::API::None:    
-			EG_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); 
+		case RendererAPI::API::None:
+			EG_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
 			ConsolePanel::Log("File: UniformBuffer.cpp - RendererAPI::None is currently not supported!", ConsolePanel::LogType::Error);
 			return nullptr;
-		case RendererAPI::API::OpenGL:  
+		case RendererAPI::API::OpenGL:
 			ConsolePanel::Log("File: UniformBuffer.cpp - Successfully Created UniformBuffer", ConsolePanel::LogType::Info);
 			return CreateRef<OpenGLUniformBuffer>(size, binding);
 		}

--- a/Engine/src/Engine/Renderer/VertexArray.cpp
+++ b/Engine/src/Engine/Renderer/VertexArray.cpp
@@ -9,13 +9,14 @@
 namespace eg {
 	Ref<VertexArray> VertexArray::Create()
 	{
+        EG_PROFILE_FUNCTION();
 		switch (Renderer::GetAPI())
 		{
-		case RendererAPI::API::None: 
-			EG_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); 
+		case RendererAPI::API::None:
+			EG_CORE_ASSERT(false, "RendererAPI::None is currently not supported!");
 			ConsolePanel::Log("File: VertexArray.cpp - RendererAPI::None is currently not supported!", ConsolePanel::LogType::Error);
 			return nullptr;
-		case RendererAPI::API::OpenGL: 
+		case RendererAPI::API::OpenGL:
 			ConsolePanel::Log("File: VertexArray.cpp - Successfully created VertexArray", ConsolePanel::LogType::Info);
 			return std::make_shared<OpenGLVertexArray>();
 		}

--- a/Engine/src/Engine/Resources/AssetDirectory.cpp
+++ b/Engine/src/Engine/Resources/AssetDirectory.cpp
@@ -7,6 +7,7 @@ namespace eg
 	AssetDirectory::AssetDirectory(UUID uuid, const std::string& name, const UUID& parentDirectory)
 		: m_Name(name), m_ParentDirectory(0)
 	{
+        EG_PROFILE_FUNCTION();
 		m_ParentDirectory = parentDirectory;
 
 		AssetDirectoryManager::addAssetDirectory(uuid, this);

--- a/Engine/src/Engine/Resources/AssetDirectoryManager.cpp
+++ b/Engine/src/Engine/Resources/AssetDirectoryManager.cpp
@@ -9,6 +9,7 @@ namespace eg
 
 	UUID AssetDirectoryManager::GetRootAssetTypeDirectory(ResourceType type)
 	{
+        EG_PROFILE_FUNCTION();
 		for (auto& [uuid, assetDirectory] : assetDirectories)
 		{
 			if (assetDirectory->getParentDirectory() == rootDirectoryUUID)
@@ -24,6 +25,7 @@ namespace eg
 
 	std::string AssetDirectoryManager::getDirectoryName(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(uuid) == assetDirectories.end())
 		{
 			EG_CORE_WARN("AssetDirectory with UUID {0} not found", uuid);
@@ -36,6 +38,7 @@ namespace eg
 
 	std::vector<UUID>& AssetDirectoryManager::getAssets(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(uuid) == assetDirectories.end())
 		{
 			EG_CORE_WARN("AssetDirectory with UUID {0} not found", uuid);
@@ -49,6 +52,7 @@ namespace eg
 
 	std::vector<UUID>& AssetDirectoryManager::getSubdirectories(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(uuid) == assetDirectories.end())
 		{
 			EG_CORE_WARN("AssetDirectory with UUID {0} not found", uuid);
@@ -62,6 +66,7 @@ namespace eg
 
 	UUID AssetDirectoryManager::getParentDirectoryUUID(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(uuid) == assetDirectories.end())
 		{
 			EG_CORE_WARN("AssetDirectory with UUID {0} not found", uuid);
@@ -74,6 +79,7 @@ namespace eg
 
 	void AssetDirectoryManager::initDefault(UUID rootUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		rootDirectoryUUID = rootUUID;
 
 		AssetDirectory* textures = new AssetDirectory(UUID(), "Textures", rootUUID);
@@ -94,7 +100,7 @@ namespace eg
 		AssetDirectory* scripts = new AssetDirectory(scriptDiectoryUUID, "Scripts", rootUUID);
 
 		AssetDirectory* scriptsSource = new AssetDirectory(UUID(), "Source", scriptDiectoryUUID);
-		
+
 		AssetDirectory* audio = new AssetDirectory(UUID(), "Audio", rootUUID);
 
 		AssetDirectory* scenes = new AssetDirectory(UUID(), "Scenes", rootUUID);
@@ -102,6 +108,7 @@ namespace eg
 
 	bool AssetDirectoryManager::moveAssetDirectory(UUID assetDirectoryUUID, UUID newParentUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(assetDirectoryUUID) == assetDirectories.end())
 		{
 			EG_CORE_WARN("AssetDirectory with UUID {0} not found", assetDirectoryUUID);
@@ -134,12 +141,14 @@ namespace eg
 
 	bool AssetDirectoryManager::moveAsset(UUID assetUUID, UUID newAssetDirectoryUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		ResourceData* data = (ResourceData*)ResourceDatabase::GetResourceData(assetUUID);
 		return moveAsset(assetUUID, data->ParentDirectory, newAssetDirectoryUUID);
 	}
 
 	bool AssetDirectoryManager::moveAsset(UUID assetUUID, UUID oldAssetDirectoryUUID, UUID newAssetDirectoryUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(newAssetDirectoryUUID) == assetDirectories.end())
 		{
 			EG_CORE_WARN("AssetDirectory with UUID {0} not found", newAssetDirectoryUUID);
@@ -165,6 +174,7 @@ namespace eg
 
 	bool AssetDirectoryManager::changeAssetDirectoryName(UUID uuid, const std::string& newName)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(uuid) == assetDirectories.end())
 		{
 			EG_CORE_WARN("AssetDirectory with UUID {0} not found", uuid);
@@ -183,6 +193,7 @@ namespace eg
 
 	bool AssetDirectoryManager::addAsset(UUID assetDirectoryUUID, UUID assetUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(assetDirectoryUUID) == assetDirectories.end())
 		{
 			EG_CORE_WARN("AssetDirectory with UUID {0} not found", assetDirectoryUUID);
@@ -204,6 +215,7 @@ namespace eg
 
 	bool AssetDirectoryManager::removeAsset(UUID assetDirectoryUUID, UUID assetUUID, bool deleteFile)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(assetDirectoryUUID) == assetDirectories.end())
 		{
 			EG_CORE_WARN("AssetDirectory with UUID {0} not found", assetDirectoryUUID);
@@ -230,6 +242,7 @@ namespace eg
 
 	void AssetDirectoryManager::removeAssetDirectory(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(uuid) == assetDirectories.end())
 		{
 			EG_CORE_WARN("AssetDirectory with UUID {0} not found", uuid);
@@ -263,6 +276,7 @@ namespace eg
 
 	void AssetDirectoryManager::addAssetDirectory(UUID uuid, AssetDirectory* assetDirectory)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(uuid) == assetDirectories.end())
 			assetDirectories[uuid] = assetDirectory;
 		else
@@ -279,6 +293,7 @@ namespace eg
 
 	bool AssetDirectoryManager::removeSubDirectory(UUID parentUUID, UUID subdirectoryUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(parentUUID) == assetDirectories.end())
 		{
 			EG_CORE_WARN("Parent AssetDirectory with UUID {0} not found", parentUUID);
@@ -312,6 +327,7 @@ namespace eg
 
 	bool AssetDirectoryManager::addSubDirectory(UUID parentUUID, UUID subdirectoryUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(parentUUID) == assetDirectories.end())
 		{
 			EG_CORE_WARN("Parent AssetDirectory with UUID {0} not found", parentUUID);
@@ -349,14 +365,16 @@ namespace eg
 
 	bool AssetDirectoryManager::findAssetDirectory(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		return assetDirectories.find(uuid) != assetDirectories.end();
 	}
 
 	bool AssetDirectoryManager::validateAssetDirectory(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(uuid) == assetDirectories.end())
 			return false;
-		
+
 		std::filesystem::path path = AssetDirectoryManager::getDirectoryPath(uuid);
 
 		if (!std::filesystem::exists(path))
@@ -367,6 +385,7 @@ namespace eg
 
 	AssetDirectory* AssetDirectoryManager::getAssetDirectory(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		if(assetDirectories.find(uuid) != assetDirectories.end())
 			return assetDirectories.at(uuid);
 		else
@@ -378,6 +397,7 @@ namespace eg
 
 	std::filesystem::path AssetDirectoryManager::getDirectoryPath(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(uuid) == assetDirectories.end())
 			return std::filesystem::path();
 
@@ -391,6 +411,7 @@ namespace eg
 
 	std::filesystem::path AssetDirectoryManager::getDirectoryPath(UUID uuid, std::filesystem::path& path)
 	{
+        EG_PROFILE_FUNCTION();
 		if (assetDirectories.find(uuid) == assetDirectories.end())
 			return std::filesystem::path();
 

--- a/Engine/src/Engine/Resources/AssetDirectorySerializer.cpp
+++ b/Engine/src/Engine/Resources/AssetDirectorySerializer.cpp
@@ -8,6 +8,7 @@ namespace eg
 {
 	bool AssetDirectorySerializer::DeserializeAssetDirectoryCache()
 	{
+        EG_PROFILE_FUNCTION();
 		std::filesystem::path metadata = ResourceUtils::GetAssetDirectoryMetadataPath();
 
 		YAML::Node node;
@@ -72,6 +73,7 @@ namespace eg
 
 	void AssetDirectorySerializer::SerializeAssetDirectoryCache()
 	{
+        EG_PROFILE_FUNCTION();
 		EG_CORE_TRACE("Serializing Asset Directory Cache");
 
 		std::filesystem::path metadataPath = ResourceUtils::GetAssetDirectoryMetadataPath();
@@ -115,7 +117,7 @@ namespace eg
 		out << YAML::EndMap;
 
 		std::ofstream fout(metadataPath);
-		
+
 		fout << out.c_str();
 
 		fout.close();

--- a/Engine/src/Engine/Resources/ResourceDatabase.cpp
+++ b/Engine/src/Engine/Resources/ResourceDatabase.cpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 #include "egpch.h"
-#include "Engine/Project/Project.h"	
+#include "Engine/Project/Project.h"
 #include <yaml-cpp/yaml.h>
 #include "ResourceUtils.h"
 #include "Systems/ResourceSystem.h"
@@ -18,6 +18,7 @@ namespace eg
 
 	void ResourceDatabase::EnableScript(UUID uuid, bool enable)
 	{
+        EG_PROFILE_FUNCTION();
 		if (ResourceSerializer::ScriptResourceDataCache.find(uuid) != ResourceSerializer::ScriptResourceDataCache.end())
 			((ScriptResourceData*)ResourceSerializer::ScriptResourceDataCache.at(uuid))->IsEnabled = enable;
 		else
@@ -26,6 +27,7 @@ namespace eg
 
 	bool ResourceDatabase::IsScriptEnabled(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		if (ResourceSerializer::ScriptResourceDataCache.find(uuid) != ResourceSerializer::ScriptResourceDataCache.end())
 			return ((ScriptResourceData*)ResourceSerializer::ScriptResourceDataCache.at(uuid))->IsEnabled;
 		else
@@ -37,6 +39,7 @@ namespace eg
 
 	bool ResourceDatabase::FindRuntimeResource(UUID uuid, ResourceType type)
 	{
+        EG_PROFILE_FUNCTION();
 		if (type == ResourceType::Font)
 			return RuntimeFontResourceCache.find(uuid) != RuntimeFontResourceCache.end();
 		else if(type == ResourceType::Image)
@@ -50,6 +53,7 @@ namespace eg
 
 	void* ResourceDatabase::AddRuntimeResource(UUID uuid, void* data, ResourceType type)
 	{
+        EG_PROFILE_FUNCTION();
 		if (data == nullptr)
 			return nullptr;
 
@@ -74,6 +78,7 @@ namespace eg
 
 	Ref<Font> ResourceDatabase::GetFontRuntimeResource(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		if(RuntimeFontResourceCache.find(uuid) != RuntimeFontResourceCache.end())
 			return RuntimeFontResourceCache.at(uuid);
 		else
@@ -91,6 +96,7 @@ namespace eg
 
 	Ref<Texture2D> ResourceDatabase::GetTextureRuntimeResource(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		if (RuntimeTextureResourceCache.find(uuid) != RuntimeTextureResourceCache.end())
 			return RuntimeTextureResourceCache.at(uuid);
 		else
@@ -108,6 +114,7 @@ namespace eg
 
 	void* ResourceDatabase::GetRuntimeResource(UUID uuid, ResourceType type)
 	{
+        EG_PROFILE_FUNCTION();
 		if (type == ResourceType::Font)
 		{
 			if (FindRuntimeResource(uuid, type))
@@ -131,6 +138,7 @@ namespace eg
 
 	void ResourceDatabase::SetResourceData(UUID uuid, ResourceType resourceType, void* data)
 	{
+        EG_PROFILE_FUNCTION();
 		switch (resourceType)
 		{
 		case eg::ResourceType::Animation:
@@ -170,11 +178,13 @@ namespace eg
 
 	ResourceType ResourceDatabase::GetResourceType(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		return ResourceSerializer::ResourceTypeInfo.at(uuid);
 	}
 
 	bool ResourceDatabase::FindResourceData(UUID uuid, ResourceType resourceType)
 	{
+        EG_PROFILE_FUNCTION();
 		if (resourceType == ResourceType::Image)
 			return ResourceSerializer::TextureResourceDataCache.find(uuid) != ResourceSerializer::TextureResourceDataCache.end();
 		else if (resourceType == ResourceType::SubTexture)
@@ -198,6 +208,7 @@ namespace eg
 
 	UUID ResourceDatabase::GetResourceByName(const std::string& name, ResourceType type)
 	{
+        EG_PROFILE_FUNCTION();
 		if (type == ResourceType::Image)
 		{
 			for (auto& [uuid, data] : ResourceSerializer::TextureResourceDataCache)
@@ -264,11 +275,13 @@ namespace eg
 
 	void ResourceDatabase::RemoveResource(UUID uuid, bool deleteFile)
 	{
+        EG_PROFILE_FUNCTION();
 		ResourceDatabase::RemoveResource(uuid, ResourceSerializer::ResourceTypeInfo.at(uuid), deleteFile);
 	}
 
 	void ResourceDatabase::RemoveResource(UUID uuid, ResourceType resourceType, bool deleteFile)
 	{
+        EG_PROFILE_FUNCTION();
 		if (resourceType == ResourceType::Image)
 		{
 			if (ResourceSerializer::TextureResourceDataCache.find(uuid) != ResourceSerializer::TextureResourceDataCache.end())
@@ -380,6 +393,7 @@ namespace eg
 
 	void* ResourceDatabase::GetResourceData(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		if (ResourceSerializer::ResourceTypeInfo.find(uuid) == ResourceSerializer::ResourceTypeInfo.end())
 		{
 			EG_CORE_ERROR("Resource not found in cache");
@@ -413,11 +427,13 @@ namespace eg
 
 	bool ResourceDatabase::FindResourceData(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		return ResourceSerializer::ResourceTypeInfo.find(uuid) != ResourceSerializer::ResourceTypeInfo.end();
 	}
 
 	std::filesystem::path ResourceDatabase::GetResourcePath(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		ResourceData* data = (ResourceData*)ResourceDatabase::GetResourceData(uuid);
 
 		return AssetDirectoryManager::getDirectoryPath(data->ParentDirectory) / std::string(data->ResourceName + data->Extension);
@@ -425,16 +441,19 @@ namespace eg
 
 	std::filesystem::path ResourceDatabase::GetResourcePath(std::filesystem::path path, ResourceType type)
 	{
+        EG_PROFILE_FUNCTION();
 		return AssetDirectoryManager::getDirectoryPath(AssetDirectoryManager::GetRootAssetTypeDirectory(type)) / path.filename();
 	}
 
 	std::filesystem::path ResourceDatabase::GetResourcePath(std::filesystem::path path)
 	{
+        EG_PROFILE_FUNCTION();
 		return AssetDirectoryManager::getDirectoryPath(m_CurrentDirectory) / path.filename();
 	}
 
 	bool ResourceDatabase::MoveResource(UUID uuid, UUID parentDirectory)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!FindResourceData(uuid))
 		{
 			EG_CORE_ERROR("Resource not found in cache");
@@ -460,6 +479,7 @@ namespace eg
 
 	bool ResourceDatabase::RenameResource(UUID uuid, const std::string& name)
 	{
+        EG_PROFILE_FUNCTION();
 		if(!FindResourceData(uuid))
 		{
 			EG_CORE_ERROR("Resource not found in cache");
@@ -479,6 +499,7 @@ namespace eg
 
 	void AddTextureResource(UUID uuid, const std::filesystem::path& originalResourcePath, TextureResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		std::filesystem::path finalPath = ResourceDatabase::GetResourcePath(originalResourcePath, ResourceType::Image);
 
 		if (finalPath != originalResourcePath)
@@ -496,6 +517,7 @@ namespace eg
 
 	void AddSubTextureResource(UUID uuid, const std::filesystem::path& originalResourcePath, SubTextureResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		std::filesystem::path finalPath = ResourceDatabase::GetResourcePath(originalResourcePath, ResourceType::SubTexture);
 
 		if (finalPath != originalResourcePath)
@@ -511,6 +533,7 @@ namespace eg
 
 	void AddFrameResource(UUID uuid, const std::filesystem::path& originalResourcePath, FrameResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		std::filesystem::path finalPath = ResourceDatabase::GetResourcePath(originalResourcePath, ResourceType::Frame);
 
 		if (finalPath != originalResourcePath)
@@ -526,6 +549,7 @@ namespace eg
 
 	void AddFontResourceData(UUID uuid, const std::filesystem::path& originalResourcePath, FontResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		std::filesystem::path finalPath = ResourceDatabase::GetResourcePath(originalResourcePath, ResourceType::Font);
 
 		if (finalPath != originalResourcePath)
@@ -543,6 +567,7 @@ namespace eg
 
 	void AddScriptResourceData(UUID uuid, const std::filesystem::path& originalResource, ScriptResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		std::filesystem::path finalPath = ResourceDatabase::GetResourcePath(originalResource, ResourceType::Script);
 
 		if (!std::filesystem::exists(finalPath.parent_path()))
@@ -555,6 +580,7 @@ namespace eg
 
 	void AddAnimationResource(UUID uuid, const std::filesystem::path& originalResourcePath, AnimationResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		std::filesystem::path finalPath = ResourceDatabase::GetResourcePath(originalResourcePath, ResourceType::Animation);
 
 		if (!std::filesystem::exists(finalPath.parent_path()))
@@ -567,6 +593,7 @@ namespace eg
 
 	void AddSpriteAtlasResource(UUID uuid, const std::filesystem::path& originalResourcePath, SpriteAtlasResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		std::filesystem::path finalPath = ResourceDatabase::GetResourcePath(originalResourcePath, ResourceType::SpriteAtlas);
 
 		if (finalPath != originalResourcePath)
@@ -582,6 +609,7 @@ namespace eg
 
 	void AddAudioResource(UUID uuid, const std::filesystem::path& originalResourcePath, AudioResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		std::filesystem::path finalPath = ResourceDatabase::GetResourcePath(originalResourcePath, ResourceType::Audio);
 
 		if (finalPath != originalResourcePath)
@@ -597,6 +625,7 @@ namespace eg
 
 	UUID ResourceDatabase::GetResourceParentDirectory(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		ResourceData* data = (ResourceData*)ResourceDatabase::GetResourceData(uuid);
 
 		return data->ParentDirectory;
@@ -604,6 +633,7 @@ namespace eg
 
 	UUID ResourceDatabase::LoadResource(const std::filesystem::path& filePath)
 	{
+        EG_PROFILE_FUNCTION();
 		ResourceType type = ResourceUtils::GetResourceTypeByExtension(filePath.extension().string());
 
 		/*if (ResourceDatabase::FindResourceByKeyPath(ResourceUtils::GetKeyPath(filePath), type) != 0)
@@ -665,6 +695,7 @@ namespace eg
 
 	void* ResourceDatabase::LoadRuntimeResource(UUID uuid, ResourceType type)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!FindResourceData(uuid, type))
 		{
 			EG_CORE_ERROR("Resource not found in cache");
@@ -702,6 +733,7 @@ namespace eg
 
 	UUID ResourceDatabase::GetResourceByData(void* data)
 	{
+        EG_PROFILE_FUNCTION();
 		ResourceData* resourceData = (ResourceData*)data;
 
 		UUID parentDirectory = resourceData->ParentDirectory;
@@ -722,6 +754,7 @@ namespace eg
 
 	std::string ResourceDatabase::GetResourceName(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!FindResourceData(uuid))
 		{
 			EG_CORE_ERROR("Resource not found in cache");
@@ -735,6 +768,7 @@ namespace eg
 
 	UUID ResourceDatabase::AddResource(const std::filesystem::path& originalResourcePath, void* data, ResourceType resourceType)
 	{
+        EG_PROFILE_FUNCTION();
 		UUID uuid = GetResourceByData(data);
 
 		if (uuid != 0)

--- a/Engine/src/Engine/Resources/ResourceSerializer.cpp
+++ b/Engine/src/Engine/Resources/ResourceSerializer.cpp
@@ -28,6 +28,7 @@ namespace eg
 
 	bool ResourceSerializer::DeserializeResourceCache()
 	{
+        EG_PROFILE_FUNCTION();
 		AssetDirectorySerializer::DeserializeAssetDirectoryCache();
 
 		std::filesystem::path textureMetadataPath = ResourceUtils::GetMetadataPath(ResourceType::Image);
@@ -224,7 +225,7 @@ namespace eg
 				TextureResourceData* data = new TextureResourceData();
 				if(resource["ParentDirectory"])
 					data->ParentDirectory = resource["ParentDirectory"].as<UUID>();
-				else 
+				else
 					data->ParentDirectory = 0;
 				if(resource["ResourceName"])
 					data->ResourceName = resource["ResourceName"].as<std::string>();
@@ -355,7 +356,7 @@ namespace eg
 
 					CacheSpriteAtlas(uuid, data);
 				}
-			} 
+			}
 
 			if (scriptResources)
 			{
@@ -423,6 +424,7 @@ namespace eg
 
 	void ResourceSerializer::SerializeResourceCache()
 	{
+        EG_PROFILE_FUNCTION();
 		AssetDirectorySerializer::SerializeAssetDirectoryCache();
 
 		std::filesystem::path textureMetadataPath = ResourceUtils::GetMetadataPath(ResourceType::Image);
@@ -605,7 +607,7 @@ namespace eg
 			scriptOut << YAML::Key << "Extension" << YAML::Value << value->Extension;
 			scriptOut << YAML::Key << "IsEnabled" << YAML::Value << value->IsEnabled;
 			scriptOut << YAML::Key << "Methods" << YAML::Value << YAML::BeginSeq;
-			
+
 			for (auto& [key2, value2] : value->Methods)
 			{
 				scriptOut << YAML::BeginMap;
@@ -630,7 +632,7 @@ namespace eg
 
 		scriptOut << YAML::EndSeq;
 		scriptOut << YAML::EndMap;
-		
+
 		audioOut << YAML::BeginMap;
 		audioOut << YAML::Key << "Resources" << YAML::Value << YAML::BeginSeq;
 
@@ -677,6 +679,7 @@ namespace eg
 
 	void ResourceSerializer::CacheTexture(UUID uuid, TextureResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		//std::filesystem::path finalPath = ResourceDatabase::GetResourcePath(uuid);
 
 		//if (!std::filesystem::exists(finalPath))
@@ -709,6 +712,7 @@ namespace eg
 
 	void ResourceSerializer::CacheSubTexture(UUID uuid, SubTextureResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		if (SubTextureResourceDataCache.find(uuid) != SubTextureResourceDataCache.end())
 		{
 			if (SubTextureResourceDataCache[uuid] != nullptr)
@@ -724,6 +728,7 @@ namespace eg
 
 	void ResourceSerializer::CacheFont(UUID uuid, FontResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		/*std::filesystem::path finalPath = ResourceDatabase::GetResourcePath(uuid);
 
 		if (!std::filesystem::exists(finalPath))
@@ -756,6 +761,7 @@ namespace eg
 
 	void ResourceSerializer::CacheScript(UUID uuid, ScriptResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		if (ScriptResourceDataCache.find(uuid) != ScriptResourceDataCache.end())
 		{
 			if (ScriptResourceDataCache[uuid] != nullptr)
@@ -771,6 +777,7 @@ namespace eg
 
 	void ResourceSerializer::CacheAudio(UUID uuid, AudioResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		if (AudioResourceDataCache.find(uuid) != AudioResourceDataCache.end())
 		{
 			if (AudioResourceDataCache[uuid] != nullptr)
@@ -786,6 +793,7 @@ namespace eg
 
 	void ResourceSerializer::CacheAnimation(UUID uuid, AnimationResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		if (AnimationResourceDataCache.find(uuid) != AnimationResourceDataCache.end())
 		{
 			if (AnimationResourceDataCache[uuid] != nullptr)
@@ -801,6 +809,7 @@ namespace eg
 
 	void ResourceSerializer::CacheFrame(UUID uuid, FrameResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		if (FrameResourceDataCache.find(uuid) != FrameResourceDataCache.end())
 		{
 			if (FrameResourceDataCache[uuid] != nullptr)
@@ -812,11 +821,12 @@ namespace eg
 		FrameResourceDataCache[uuid] = data;
 		ResourceTypeInfo[uuid] = ResourceType::Frame;
 		AssetDirectoryManager::addAsset(data->ParentDirectory, uuid);
-	
+
 	}
 
 	void ResourceSerializer::CacheSpriteAtlas(UUID uuid, SpriteAtlasResourceData* data)
 	{
+        EG_PROFILE_FUNCTION();
 		if (SpriteAtlasResourceDataCache.find(uuid) != SpriteAtlasResourceDataCache.end())
 		{
 			if (SpriteAtlasResourceDataCache[uuid] != nullptr)

--- a/Engine/src/Engine/Resources/Systems/ResourceSystem.cpp
+++ b/Engine/src/Engine/Resources/Systems/ResourceSystem.cpp
@@ -8,12 +8,13 @@
 //Todo: switch to Ref instead of raw pointers
 namespace eg {
 
-	
+
 
 	static Ref<ResourceSystemState> StatePtr = nullptr;
 
 	bool load(std::string name, ResourceLoader* loader, Resource* outResource)
 	{
+        EG_PROFILE_FUNCTION();
 		if (name.empty() || loader == nullptr || outResource == nullptr)
 		{
 			EG_CORE_ERROR("Invalid arguments passed to resourceSystemLoad");
@@ -27,6 +28,7 @@ namespace eg {
 
 	bool resourceSystemInit(ResourceSystemConfig config)
 	{
+        EG_PROFILE_FUNCTION();
 		if (config.MaxLoaderCount == 0)
 		{
 			EG_CORE_ERROR("Invalid MaxLoaderCount passed to resourceSystemInit");
@@ -52,6 +54,7 @@ namespace eg {
 
 	void resourceSystemShutdown()
 	{
+        EG_PROFILE_FUNCTION();
 		if (StatePtr)
 		{
 			StatePtr = nullptr;
@@ -60,6 +63,7 @@ namespace eg {
 
 	bool resourceSystemRegisterLoader(Ref<ResourceSystemState> state, const ResourceLoader loader)
 	{
+        EG_PROFILE_FUNCTION();
 		if (StatePtr) {
 			uint32_t count = StatePtr->Config.MaxLoaderCount;
 			//Ensure no loader with the given type is already registered
@@ -77,7 +81,7 @@ namespace eg {
 					{
 							EG_ERROR("A loader with the given custom type is already registered");
 							return false;
-					}	
+					}
 				}
 			}
 			for (uint32_t i = 0; i < count; i++)
@@ -97,6 +101,7 @@ namespace eg {
 
 	bool resourceSystemLoad(std::string name, ResourceType resourceType, Resource* outResource)
 	{
+        EG_PROFILE_FUNCTION();
 		if (StatePtr && resourceType != ResourceType::Custom)
 		{
 			uint32_t count = StatePtr->Config.MaxLoaderCount;
@@ -113,6 +118,7 @@ namespace eg {
 
 	bool resourceSystemLoadCustom(std::string name, std::string customType, Resource* outResource)
 	{
+        EG_PROFILE_FUNCTION();
 		if (StatePtr && !customType.empty())
 		{
 			uint32_t count = StatePtr->Config.MaxLoaderCount;
@@ -129,6 +135,7 @@ namespace eg {
 
 	void resourceSystemUnload(Resource* resource)
 	{
+        EG_PROFILE_FUNCTION();
 		if (StatePtr && resource)
 		{
 			if (resource->LoaderId != -1)
@@ -144,13 +151,14 @@ namespace eg {
 
 	const std::filesystem::path resourceSystemGetResourceDirectory()
 	{
+        EG_PROFILE_FUNCTION();
 		if (StatePtr)
 			return StatePtr->Config.ResourceDirectory;
-		
+
 		EG_ERROR("Resource system not initialized");
 		return std::filesystem::path();
 	}
 
-	
+
 
 }

--- a/Engine/src/Engine/Resources/loaders/BinaryLoader.cpp
+++ b/Engine/src/Engine/Resources/loaders/BinaryLoader.cpp
@@ -7,6 +7,7 @@ namespace eg
 {
 	bool binaryLoaderLoad(ResourceLoader* loader, std::string name, Resource* resource)
 	{
+        EG_PROFILE_FUNCTION();
 		if (loader == nullptr || resource == nullptr)
 		{
 			EG_CORE_ERROR("Invalid arguments passed to binaryLoaderLoad");
@@ -36,6 +37,7 @@ namespace eg
 
 	ResourceLoader binaryResourceLoaderCreate()
 	{
+        EG_PROFILE_FUNCTION();
 		return ResourceLoader();
 	}
 }

--- a/Engine/src/Engine/Resources/loaders/FontLoader.cpp
+++ b/Engine/src/Engine/Resources/loaders/FontLoader.cpp
@@ -14,6 +14,7 @@ namespace eg
 	template<typename T, typename S, int N, msdf_atlas::GeneratorFunction<S, N> GenFunc>
 	static Ref<Texture2D> CreateAndCacheAtlas(const std::string& fontName, float fontSize, const std::vector<msdf_atlas::GlyphGeometry>& glyphs, const msdf_atlas::FontGeometry& fontGeometry, uint32_t width, uint32_t height)
 	{
+        EG_PROFILE_FUNCTION();
 		msdf_atlas::GeneratorAttributes attributes;
 		attributes.config.overlapSupport = true;
 		attributes.scanlinePass = true;
@@ -38,6 +39,7 @@ namespace eg
 
 	bool fontLoaderLoad(ResourceLoader* loader, std::string name, Resource* outResource)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!loader || name.empty() || !outResource)
 		{
 			return false;
@@ -139,6 +141,7 @@ namespace eg
 
 	void fontLoaderUnload(ResourceLoader* loader, Resource* resource)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!loader || !resource)
 		{
 			EG_ERROR("Invalid resource or loader passed to fontLoaderUnload");
@@ -156,6 +159,7 @@ namespace eg
 
 	ResourceLoader fontResourceLoaderCreate()
 	{
+        EG_PROFILE_FUNCTION();
 		ResourceLoader loader;
 		loader.Type = ResourceType::Font;
 		loader.load = fontLoaderLoad;

--- a/Engine/src/Engine/Resources/loaders/ImageLoader.cpp
+++ b/Engine/src/Engine/Resources/loaders/ImageLoader.cpp
@@ -8,6 +8,7 @@ namespace eg
 {
 	bool imageLoaderLoad(ResourceLoader *loader, std::string name, Resource *outResource)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!loader || name.empty() || !outResource)
 		{
 			return false;
@@ -54,6 +55,7 @@ namespace eg
 
 	void imageLoaderUnload(ResourceLoader *loader, Resource *resource)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!loader || !resource)
 		{
 			EG_ERROR("imageLoaderUnload called with nullptr");
@@ -73,6 +75,7 @@ namespace eg
 
 	ResourceLoader imageResourceLoaderCreate()
 	{
+        EG_PROFILE_FUNCTION();
 		ResourceLoader loader;
 		loader.Type = ResourceType::Image;
 		loader.load = imageLoaderLoad;

--- a/Engine/src/Engine/Resources/loaders/TextLoader.cpp
+++ b/Engine/src/Engine/Resources/loaders/TextLoader.cpp
@@ -9,6 +9,7 @@ namespace eg
 
 	bool textLoaderLoad(ResourceLoader* loader, std::string name, Resource* outResource)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!loader || name.empty() || !outResource)
 		{
 			EG_CORE_ERROR("textLoaderLoad called with nullptr");
@@ -42,6 +43,7 @@ namespace eg
 
 	void textLoaderUnload(ResourceLoader* loader, Resource* resource)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!loader || !resource)
 		{
 			EG_CORE_WARN("textLoaderUnload called with nullptr");
@@ -59,6 +61,7 @@ namespace eg
 
 	ResourceLoader textResourceLoaderCreate()
 	{
+        EG_PROFILE_FUNCTION();
 		ResourceLoader loader;
 		loader.Type = ResourceType::Text;
 		loader.load = textLoaderLoad;

--- a/Engine/src/Engine/Scene/ColliderEvents.cpp
+++ b/Engine/src/Engine/Scene/ColliderEvents.cpp
@@ -7,8 +7,9 @@ namespace eg
 {
 	void ContactListener::BeginContact(b2Contact* contact)
 	{
+        EG_PROFILE_FUNCTION();
 		InternalCollision2DEvent collision;
-		
+
 		UUID entityA = contact->GetFixtureA()->GetUserData().pointer;
 		UUID entityB = contact->GetFixtureB()->GetUserData().pointer;
 
@@ -34,6 +35,7 @@ namespace eg
 
 	void ContactListener::EndContact(b2Contact* contact)
 	{
+        EG_PROFILE_FUNCTION();
 		InternalCollision2DEvent collision;
 
 		UUID entityA = contact->GetFixtureA()->GetUserData().pointer;

--- a/Engine/src/Engine/Scene/Entity.cpp
+++ b/Engine/src/Engine/Scene/Entity.cpp
@@ -5,11 +5,13 @@ namespace eg {
 	Entity::Entity(entt::entity handle, Scene* scene)
 		: m_EntityHandle(handle), m_Scene(scene)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	template<>
 	void Entity::SetComponent<TagComponent>(Entity& entity, TagComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<TagComponent>())
 			entity.AddComponent<TagComponent>();
 
@@ -22,6 +24,7 @@ namespace eg {
 	template<>
 	void Entity::SetComponent<TransformComponent>(Entity& entity, TransformComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<TransformComponent>())
 			entity.AddComponent<TransformComponent>();
 
@@ -38,6 +41,7 @@ namespace eg {
 	template<>
 	void Entity::SetComponent<SpriteRendererComponent>(Entity& entity, SpriteRendererComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<SpriteRendererComponent>())
 			entity.AddComponent<SpriteRendererComponent>();
 
@@ -55,6 +59,7 @@ namespace eg {
 	template<>
 	void Entity::SetComponent<SpriteRendererSTComponent>(Entity& entity, SpriteRendererSTComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<SpriteRendererSTComponent>())
 			entity.AddComponent<SpriteRendererSTComponent>();
 
@@ -71,6 +76,7 @@ namespace eg {
 	template<>
 	void Entity::SetComponent<CameraComponent>(Entity& entity, CameraComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<CameraComponent>())
 			entity.AddComponent<CameraComponent>();
 
@@ -89,6 +95,7 @@ namespace eg {
 	template<>
 	void Entity::SetComponent<ScriptComponent>(Entity& entity, ScriptComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<ScriptComponent>())
 			entity.AddComponent<ScriptComponent>();
 
@@ -103,6 +110,7 @@ namespace eg {
 	template<>
 	void Entity::SetComponent<NativeScriptComponent>(Entity& entity, NativeScriptComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<NativeScriptComponent>())
 			entity.AddComponent<NativeScriptComponent>();
 
@@ -113,6 +121,7 @@ namespace eg {
 	template<>
 	void Entity::SetComponent<CircleRendererComponent>(Entity& entity, CircleRendererComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<CircleRendererComponent>())
 			entity.AddComponent<CircleRendererComponent>();
 
@@ -129,6 +138,7 @@ namespace eg {
 	template<>
 	void Entity::SetComponent<BoxCollider2DComponent>(Entity& entity, BoxCollider2DComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<BoxCollider2DComponent>())
 			entity.AddComponent<BoxCollider2DComponent>();
 
@@ -148,6 +158,7 @@ namespace eg {
 	template<>
 	void Entity::SetComponent<CircleCollider2DComponent>(Entity& entity, CircleCollider2DComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<CircleCollider2DComponent>())
 			entity.AddComponent<CircleCollider2DComponent>();
 
@@ -167,6 +178,7 @@ namespace eg {
 	template<>
 	void Entity::SetComponent<RigidBody2DComponent>(Entity& entity, RigidBody2DComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<RigidBody2DComponent>())
 			entity.AddComponent<RigidBody2DComponent>();
 
@@ -182,6 +194,7 @@ namespace eg {
 	template<>
 	void Entity::SetComponent<TextComponent>(Entity& entity, TextComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<TextComponent>())
 			entity.AddComponent<TextComponent>();
 
@@ -200,6 +213,7 @@ namespace eg {
 	template<>
 	void Entity::SetComponent<AudioSourceComponent>(Entity& entity, AudioSourceComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<AudioSourceComponent>())
 			entity.AddComponent<AudioSourceComponent>();
 
@@ -211,6 +225,7 @@ namespace eg {
 	template<>
 	void Entity::SetComponent<AnimatorComponent>(Entity& entity, AnimatorComponent* component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!entity.HasComponent<AnimatorComponent>())
 			entity.AddComponent<AnimatorComponent>();
 

--- a/Engine/src/Engine/Scene/Scene.cpp
+++ b/Engine/src/Engine/Scene/Scene.cpp
@@ -27,19 +27,20 @@ namespace eg {
 
 	Scene::Scene()
 	{
-
+        EG_PROFILE_FUNCTION();
 	}
 
 	Scene::~Scene()
 	{
-
+        EG_PROFILE_FUNCTION();
 	}
-	
-	
+
+
 
 	template<typename... Component>
 	static void CopyComponent(entt::registry& dst, entt::registry& src, const std::unordered_map<UUID, entt::entity>& enttMap)
 	{
+        EG_PROFILE_FUNCTION();
 		([&]()
 			{
 			auto view = src.view<Component>();
@@ -56,12 +57,14 @@ namespace eg {
 	template<typename... Component>
 	static void CopyComponent(ComponentGroup<Component...>, entt::registry& dst, entt::registry& src, const std::unordered_map<UUID, entt::entity>& enttMap)
 	{
+        EG_PROFILE_FUNCTION();
 		CopyComponent<Component...>(dst, src, enttMap);
 	}
 
 	template<typename... Component>
 	static void CopyComponentIfExists(Entity dst, Entity src)
 	{
+        EG_PROFILE_FUNCTION();
 		([&]()
 			{
 				if (src.HasComponent<Component>())
@@ -72,17 +75,19 @@ namespace eg {
 	template<typename... Component>
 	static void CopyComponentIfExists(ComponentGroup<Component...>, Entity dst, Entity src)
 	{
+        EG_PROFILE_FUNCTION();
 		CopyComponentIfExists<Component...>(dst, src);
 	}
 
 	Ref<Scene> Scene::Copy(Ref<Scene>& other)
 	{
+        EG_PROFILE_FUNCTION();
 		Ref<Scene> scene = CreateRef<Scene>();
 		scene->m_ViewportWidth = other->m_ViewportWidth;
 		scene->m_ViewportHeight = other->m_ViewportHeight;
 
 		std::unordered_map<UUID, entt::entity> enttMap;
-		
+
 		auto& srcSceneRegistry = other->m_Registry;
 		auto& dstSceneRegistry = scene->m_Registry;
 		auto idView = srcSceneRegistry.view<IDComponent>();
@@ -111,11 +116,13 @@ namespace eg {
 
 	Entity Scene::CreateEntity(const std::string& name)
 	{
+        EG_PROFILE_FUNCTION();
 		return CreateEntityWithID(UUID(), name);
 	}
 
 	Entity Scene::CreateEntityWithID(UUID uuid, const std::string& name)
 	{
+        EG_PROFILE_FUNCTION();
 		Entity entity = { m_Registry.create(), this };
 		entity.AddComponent<IDComponent>(uuid);
 		entity.AddComponent<TransformComponent>(uuid);
@@ -130,6 +137,7 @@ namespace eg {
 
 	void Scene::DestroyEntity(Entity entity)
 	{
+        EG_PROFILE_FUNCTION();
 		if (entity.GetParent().has_value())
 			entity.GetParent().value().RemoveChild(entity);
 		if (m_IsRunning && entity.HasComponent<RigidBody2DComponent>())
@@ -145,6 +153,7 @@ namespace eg {
 
 	void Scene::OnRuntimeStart()
 	{
+        EG_PROFILE_FUNCTION();
 		OnPhysics2DStart();
 		m_IsRunning = true;
 		//Scripting
@@ -173,6 +182,7 @@ namespace eg {
 
 	void Scene::OnRuntimeStop()
 	{
+        EG_PROFILE_FUNCTION();
 		OnPhysics2DStop();
 		m_IsRunning = false;
 		if (EvaluateSceneAudio) {
@@ -190,6 +200,7 @@ namespace eg {
 
 	void Scene::OnSimulationStart()
 	{
+        EG_PROFILE_FUNCTION();
 		OnPhysics2DStart();
 		// Audio
 		if (EvaluateSceneAudio) {
@@ -206,15 +217,16 @@ namespace eg {
 
 	void Scene::OnSimulationStop()
 	{
+        EG_PROFILE_FUNCTION();
 		OnPhysics2DStop();
 		if (EvaluateSceneAudio) {
 			auto ASourceView = m_Registry.view<AudioSourceComponent>();
 			for (auto f : ASourceView)
 			{
-				
+
 
 					ASourceView.get<AudioSourceComponent>(f).Audio->Stop();
-				
+
 			}
 		}
 	}
@@ -222,11 +234,13 @@ namespace eg {
 
 	void Scene::OnUpdateEditor(Timestep ts, EditorCamera& camera)
 	{
+        EG_PROFILE_FUNCTION();
 		RenderScene(camera);
 	}
 
 	void Scene::FixedUpdate()
 	{
+        EG_PROFILE_FUNCTION();
 		{
 			const int32_t velocityIterations = 6;
 			const int32_t positionIterations = 2;
@@ -257,14 +271,15 @@ namespace eg {
 
 	void Scene::OnUpdateRuntime(Timestep ts,std::chrono::steady_clock::time_point& oldTime)
 	{
+        EG_PROFILE_FUNCTION();
 		m_NewTime = std::chrono::high_resolution_clock::now();
 		m_Delta = std::chrono::duration_cast<std::chrono::milliseconds>(m_NewTime - oldTime).count();
 		oldTime = m_NewTime;
-		
+
 
 		if (!m_IsPaused || m_StepFrames-- > 0)
 		{
-			
+
 			// Update Native scripts
 			{
 				//C# Entity OnUpdate
@@ -289,7 +304,7 @@ namespace eg {
 					});
 			}
 
-			
+
 
 
 
@@ -300,7 +315,7 @@ namespace eg {
 			{
 				FixedUpdate();
 				m_TimePassed = m_TimePassed - m_FixedFramerate;
-				
+
 			}
 			// Physics
 			{
@@ -373,9 +388,9 @@ namespace eg {
 					Renderer2D::DrawSprite(transform.GetTransform(), sprite, (int)entity);
 				}
 			}
-			 
+
 			//Set Animations
-			
+
 			{
 				auto group = m_Registry.view<TransformComponent, AnimatorComponent>();
 				for (auto entity : group)
@@ -399,7 +414,7 @@ namespace eg {
 					Renderer2D::DrawSprite(transform.GetTransform(), sprite, (int)entity);
 				}
 			}
-			
+
 			// Draw circles
 			{
 				auto view = m_Registry.view<TransformComponent, CircleRendererComponent>();
@@ -428,7 +443,8 @@ namespace eg {
 
 	void Scene::OnUpdateSimulation(Timestep ts, EditorCamera& camera)
 	{
-		
+        EG_PROFILE_FUNCTION();
+
 		if (!m_IsPaused || m_StepFrames-- > 0)
 			// Physics
 		{
@@ -460,6 +476,7 @@ namespace eg {
 
 	void Scene::OnViewportResize(uint32_t width, uint32_t height)
 	{
+        EG_PROFILE_FUNCTION();
 		if (m_ViewportHeight == height && m_ViewportWidth == width)
 			return;
 
@@ -479,6 +496,7 @@ namespace eg {
 
 	void Scene::RenderScene(EditorCamera& camera)
 	{
+        EG_PROFILE_FUNCTION();
 		Renderer2D::BeginScene(camera);
 		RenderAxis();
 
@@ -548,19 +566,22 @@ namespace eg {
 
 	void Scene::RenderAxis()
 	{
+        EG_PROFILE_FUNCTION();
 		//X: red
 		//y: green
 		//z: blue
-		
+
 	}
 
 	void Scene::AddEntityToDestroy(Entity entity)
 	{
+        EG_PROFILE_FUNCTION();
 		m_EntitiesToDestroy.push_back(entity  );
 	}
 
 	Entity Scene::DuplicateEntity(Entity entity)
 	{
+        EG_PROFILE_FUNCTION();
 		std::string name = entity.GetName();
 		Entity newEntity = CreateEntity(name);
 		CopyComponentIfExists(AllComponents{}, newEntity, entity);
@@ -569,6 +590,7 @@ namespace eg {
 
 	Entity Scene::FindEntityByName(const std::string_view& name)
 	{
+        EG_PROFILE_FUNCTION();
 		auto view = m_Registry.view<TagComponent>();
 		for (auto entity : view)
 		{
@@ -580,6 +602,7 @@ namespace eg {
 	}
 
 	void Scene::FindEntitiesByName(const std::string_view& name, std::vector<Entity>& outVec) {
+        EG_PROFILE_FUNCTION();
 		auto view  = m_Registry.view<TagComponent>();
 		for (auto entity : view)
 		{
@@ -591,6 +614,7 @@ namespace eg {
 
 	Entity Scene::GetEntityByUUID(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		//TODO: Maybe should assert
 		if(m_EntityMap.find(uuid) != m_EntityMap.end())
 			return Entity{ m_EntityMap[uuid], this };
@@ -599,11 +623,13 @@ namespace eg {
 
 	bool Scene::EntityExists(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		return m_EntityMap.find(uuid) != m_EntityMap.end();
 	}
 
 	Entity Scene::GetPrimaryCameraEntity()
 	{
+        EG_PROFILE_FUNCTION();
 		auto view = m_Registry.view<CameraComponent>();
 		for (auto entity : view)
 		{
@@ -616,11 +642,13 @@ namespace eg {
 
 	void Scene::Step(int frames)
 	{
+        EG_PROFILE_FUNCTION();
 		m_StepFrames = frames;
 	}
 
 	void Scene::AwakeRuntimeBody(Entity entity)
 	{
+        EG_PROFILE_FUNCTION();
 		auto& transform = entity.GetComponent<TransformComponent>();
 		auto& rb = entity.GetComponent<RigidBody2DComponent>();
 
@@ -676,6 +704,7 @@ namespace eg {
 
 	void* Scene::StartRuntimeBody(Entity entity)
 	{
+        EG_PROFILE_FUNCTION();
 		auto& transform = entity.GetComponent<TransformComponent>();
 		auto& rb = entity.GetComponent<RigidBody2DComponent>();
 
@@ -693,8 +722,9 @@ namespace eg {
 
 	void Scene::OnPhysics2DStart()
 	{
+        EG_PROFILE_FUNCTION();
 		m_PhysicsWorld = new b2World({ 0.0f, -9.81f });
-		
+
 		ContactListener* listener = new ContactListener();
 
 		m_PhysicsWorld->SetContactListener(listener);
@@ -745,7 +775,7 @@ namespace eg {
 				fixtureDef.restitutionThreshold = cc.RestitutionThreshold;
 				fixtureDef.userData.pointer = e.GetUUID();
 				fixtureDef.isSensor = cc.IsSensor;
-				
+
 				b2Fixture* fixture = body->CreateFixture(&fixtureDef);
 				cc.RuntimeFixture = fixture;
 			}
@@ -754,6 +784,7 @@ namespace eg {
 
 	void Scene::OnPhysics2DStop()
 	{
+        EG_PROFILE_FUNCTION();
 		delete m_PhysicsWorld;
 		m_PhysicsWorld = nullptr;
 	}
@@ -761,29 +792,34 @@ namespace eg {
 	template<typename T>
 	void Scene::OnComponentAdded(Entity entity, T& component)
 	{
+        EG_PROFILE_FUNCTION();
 		static_assert(sizeof(T) == 0);
 	}
 
-	
+
 
 	template<>
 	void Scene::OnComponentAdded<IDComponent>(Entity entity, IDComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	template<>
 	void Scene::OnComponentAdded<TagComponent>(Entity entity, TagComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	template<>
 	void Scene::OnComponentAdded<TransformComponent>(Entity entity, TransformComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	template<>
 	void Scene::OnComponentAdded<CameraComponent>(Entity entity, CameraComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 		if (m_ViewportWidth > 0 && m_ViewportHeight > 0)
 			component.Camera.SetViewportSize(m_ViewportWidth, m_ViewportHeight);
 	}
@@ -791,55 +827,66 @@ namespace eg {
 	template<>
 	void Scene::OnComponentAdded<ScriptComponent>(Entity entity, ScriptComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	template<>
 	void Scene::OnComponentAdded<SpriteRendererComponent>(Entity entity, SpriteRendererComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	template<>
 	void Scene::OnComponentAdded<CircleRendererComponent>(Entity entity, CircleRendererComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	template<>
 	void Scene::OnComponentAdded<NativeScriptComponent>(Entity entity, NativeScriptComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	template<>
 	void Scene::OnComponentAdded<BoxCollider2DComponent>(Entity entity, BoxCollider2DComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	template<>
 	void Scene::OnComponentAdded<RigidBody2DComponent>(Entity entity, RigidBody2DComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	template<>
 	void Scene::OnComponentAdded<CircleCollider2DComponent>(Entity entity, CircleCollider2DComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	template<>
 	void Scene::OnComponentAdded<TextComponent>(Entity entity, TextComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 	template<>
 	void Scene::OnComponentAdded<AudioSourceComponent>(Entity entity, AudioSourceComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	template<>
 	void Scene::OnComponentAdded<SpriteRendererSTComponent>(Entity entity, SpriteRendererSTComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	template<>
 	void Scene::OnComponentAdded<AnimatorComponent>(Entity entity, AnimatorComponent& component)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 }

--- a/Engine/src/Engine/Scene/SceneCamera.cpp
+++ b/Engine/src/Engine/Scene/SceneCamera.cpp
@@ -6,11 +6,13 @@ namespace eg {
 
 	SceneCamera::SceneCamera()
 	{
+        EG_PROFILE_FUNCTION();
 		RecalculateProjection();
 	}
 
 	void SceneCamera::SetOrthographic(float size, float nearClip, float farClip)
 	{
+        EG_PROFILE_FUNCTION();
 		m_ProjectionType = ProjectionType::Orthographic;
 		m_OrthographicSize = size;
 		m_OrthographicNear = nearClip;
@@ -20,6 +22,7 @@ namespace eg {
 
 	void SceneCamera::SetPerspective(float verticalFOV, float nearClip, float farClip)
 	{
+        EG_PROFILE_FUNCTION();
 		m_ProjectionType = ProjectionType::Perspective;
 		m_PerspectiveFOV = verticalFOV;
 		m_PerspectiveNear = nearClip;
@@ -29,6 +32,7 @@ namespace eg {
 
 	void SceneCamera::SetViewportSize(uint32_t width, uint32_t height)
 	{
+        EG_PROFILE_FUNCTION();
 		EG_CORE_ASSERT(width > 0 && height > 0);
 		m_AspectRatio = (float)width / (float)height;
 		RecalculateProjection();
@@ -36,11 +40,12 @@ namespace eg {
 
 	void SceneCamera::RecalculateProjection()
 	{
+        EG_PROFILE_FUNCTION();
 		if (m_ProjectionType == ProjectionType::Perspective)
 		{
 			m_ProjectionMatrix = glm::perspective(m_PerspectiveFOV, m_AspectRatio,
 				m_PerspectiveNear, m_PerspectiveFar);
-		
+
 		}
 		else if (m_ProjectionType == ProjectionType::Orthographic) {
 			float orthoLeft = -m_OrthographicSize * m_AspectRatio * 0.5f;

--- a/Engine/src/Engine/Scene/SceneSerializer.cpp
+++ b/Engine/src/Engine/Scene/SceneSerializer.cpp
@@ -26,10 +26,11 @@ namespace eg {
 		break;                                         \
 	}
 
-	
+
 
 	static std::string RigidBody2dBodyTypeToString(RigidBody2DComponent::BodyType bodyType)
 	{
+        EG_PROFILE_FUNCTION();
 		switch (bodyType)
 		{
 		case RigidBody2DComponent::BodyType::Static:    return "Static";
@@ -39,11 +40,12 @@ namespace eg {
 		EG_CORE_ASSERT(false, "Unknown RigidBody2DComponent::BodyType!");
 		ConsolePanel::Log("File: SceneSerializer.cpp - Unknown type of RigidBody2DComponent", ConsolePanel::LogType::Error);
 		return std::string();
-	
+
 	}
 
 	static RigidBody2DComponent::BodyType RigidBody2dBodyTypeFromString(const std::string& bodyType)
 	{
+        EG_PROFILE_FUNCTION();
 		if (bodyType == "Static")    return RigidBody2DComponent::BodyType::Static;
 		if (bodyType == "Dynamic")   return RigidBody2DComponent::BodyType::Dynamic;
 		if (bodyType == "Kinematic") return RigidBody2DComponent::BodyType::Kinematic;
@@ -55,10 +57,12 @@ namespace eg {
 	SceneSerializer::SceneSerializer(const Ref<Scene>& scene)
 		: m_Scene(scene)
 	{
+        EG_PROFILE_FUNCTION();
 	}
 
 	static void SerializeEntity(YAML::Emitter& out, Entity entity)
 	{
+        EG_PROFILE_FUNCTION();
 		EG_CORE_ASSERT(entity.HasComponent<IDComponent>(), "Entity has no IDComponent!");
 
 		out << YAML::BeginMap; // Entity
@@ -128,7 +132,7 @@ namespace eg {
 				out << YAML::Key << "MinCoords" << YAML::Value << spriteRendererComponent.SubTexture->GetCoords(0);
 				out << YAML::Key << "MaxCoords" << YAML::Value << spriteRendererComponent.SubTexture->GetCoords(2);
 			}
-			out << YAML::EndMap; 
+			out << YAML::EndMap;
 		}
 
 		if (entity.HasComponent<CircleRendererComponent>())
@@ -200,14 +204,14 @@ namespace eg {
 		if (entity.HasComponent<ScriptComponent>())
 		{
 			out << YAML::Key << "ScriptComponent";
-			out << YAML::BeginMap; 
+			out << YAML::BeginMap;
 			auto& scriptComponent = entity.GetComponent<ScriptComponent>();
 
-			out << YAML::Key << "Scripts" << YAML::Value << YAML::BeginSeq; 
+			out << YAML::Key << "Scripts" << YAML::Value << YAML::BeginSeq;
 
 			for (UUID script : scriptComponent.Scripts)
 			{
-				out << YAML::BeginMap; 
+				out << YAML::BeginMap;
 				out << YAML::Key << "ScriptUUID" << YAML::Value << script;
 
 				std::string name = ResourceDatabase::GetResourceName(script);
@@ -343,7 +347,7 @@ namespace eg {
 			out << YAML::Key << "IsLooped" << YAML::Value << audioSourceComponent.Audio->IsLooped();
 			out << YAML::Key << "IsPlayingFromStart" << YAML::Value << audioSourceComponent.Audio->IsPlayingFromStart();
 			out << YAML::Key << "Volume" << YAML::Value << audioSourceComponent.Audio->GetVolume();
-			
+
 			out << YAML::Key << "IsInherited" << YAML::Value << audioSourceComponent.isInherited;
 			out << YAML::Key << "IsInheritedInChildren" << YAML::Value << audioSourceComponent.isInheritedInChildren;
 
@@ -356,6 +360,7 @@ namespace eg {
 
 	void SceneSerializer::Serialize(const std::string& filepath)
 	{
+        EG_PROFILE_FUNCTION();
 		YAML::Emitter out;
 		out << YAML::BeginMap;
 		out << YAML::Key << "Scene" << YAML::Value << "Untitled";
@@ -382,11 +387,13 @@ namespace eg {
 
 	void SceneSerializer::SerializeRuntime(const std::string& filepath)
 	{
+        EG_PROFILE_FUNCTION();
 		EG_CORE_ASSERT(false, "Not implemented");
 	}
 
 	bool SceneSerializer::Deserialize(const std::string& filepath)
 	{
+        EG_PROFILE_FUNCTION();
 		YAML::Node data;
 		try
 		{
@@ -412,7 +419,7 @@ namespace eg {
 		{
 			for (auto entity : entities)
 			{
-				int64_t uuid = entity["Entity"].as<int64_t>(); 
+				int64_t uuid = entity["Entity"].as<int64_t>();
 
 				std::string name;
 				auto tagComponent = entity["TagComponent"];
@@ -462,7 +469,7 @@ namespace eg {
 					cc.Camera.SetPerspectiveVerticalFOV(cameraProps["PerspectiveFOV"].as<float>());
 					cc.Camera.SetPerspectiveNearClip(cameraProps["PerspectiveNear"].as<float>());
 					cc.Camera.SetPerspectiveFarClip(cameraProps["PerspectiveFar"].as<float>());
-					
+
 					cc.Camera.SetOrthographicSize(cameraProps["OrthographicSize"].as<float>());
 					cc.Camera.SetOrthographicNearClip(cameraProps["OrthographicNear"].as<float>());
 					cc.Camera.SetOrthographicFarClip(cameraProps["OrthographicFar"].as<float>());
@@ -751,6 +758,7 @@ namespace eg {
 
 	bool SceneSerializer::DeserializeRuntime(const std::string& filepath)
 	{
+        EG_PROFILE_FUNCTION();
 		EG_CORE_ASSERT(false, "Not implemented");
 		return false;
 	}

--- a/Engine/src/Engine/Scripting/ScriptGlue.cpp
+++ b/Engine/src/Engine/Scripting/ScriptGlue.cpp
@@ -22,6 +22,7 @@ namespace eg
 
 		std::string MonoStringToString(MonoString *string)
 		{
+            EG_PROFILE_FUNCTION();
 			char *cStr = mono_string_to_utf8(string);
 			std::string str(cStr);
 			mono_free(cStr);
@@ -30,6 +31,7 @@ namespace eg
 
 		const char* getSubstringAfterColon(const char *input)
 		{
+            EG_PROFILE_FUNCTION();
 			const char* colonPosition = strchr(input, ':');
 
 			if (colonPosition != nullptr)
@@ -42,6 +44,7 @@ namespace eg
 
 		const char* getSubstringAfterDot(const char *input)
 		{
+            EG_PROFILE_FUNCTION();
 			const char* colonPosition = strchr(input, '.');
 
 			if (colonPosition != nullptr)
@@ -55,6 +58,7 @@ namespace eg
 		template <typename... Component>
 		bool IsInheritedInChildren(MonoType *managedType, Entity e)
 		{
+            EG_PROFILE_FUNCTION();
 			bool isInherited = false;
 
 			([&managedType, &e, &isInherited]()
@@ -69,12 +73,14 @@ namespace eg
 		template <typename... Component>
 		bool IsInheritedInChildren(ComponentGroup<Component...>, MonoType *managedType, Entity e)
 		{
+            EG_PROFILE_FUNCTION();
 			return IsInheritedInChildren<Component...>(managedType, e);
 		}
 
 		template <typename... Component>
 		bool IsInheritedFromParent(MonoType *managedType, Entity e)
 		{
+            EG_PROFILE_FUNCTION();
 			bool isInherited = false;
 
 			([&managedType, &e, &isInherited]()
@@ -89,12 +95,14 @@ namespace eg
 		template <typename... Component>
 		bool IsInheritedFromParent(ComponentGroup<Component...>, MonoType *managedType, Entity e)
 		{
+            EG_PROFILE_FUNCTION();
 			return IsInheritedFromParent<Component...>(managedType, e);
 		}
 
 		template <typename... Component>
 		void CopyComponentToChildren(MonoType *managedType, Entity e, bool isUndo)
 		{
+            EG_PROFILE_FUNCTION();
 			([&managedType, &e, &isUndo]()
 			 {
 					if (std::strcmp(getSubstringAfterColon(typeid(Component).name()), getSubstringAfterDot(mono_type_get_name(managedType))) == 0)
@@ -105,12 +113,14 @@ namespace eg
 		template <typename... Component>
 		void CopyComponentToChildren(ComponentGroup<Component...>, MonoType *managedType, Entity e, bool isUndo)
 		{
+            EG_PROFILE_FUNCTION();
 			CopyComponentToChildren<Component...>(managedType, e, isUndo);
 		}
 
 		template <typename... Component>
 		void CopyComponentValuesToChildren(MonoType *managedType, Entity e)
 		{
+            EG_PROFILE_FUNCTION();
 			([&managedType, &e]()
 			 {
 					if (std::strcmp(getSubstringAfterColon(typeid(Component).name()), getSubstringAfterDot(mono_type_get_name(managedType))) == 0)
@@ -121,12 +131,14 @@ namespace eg
 		template <typename... Component>
 		void CopyComponentValuesToChildren(ComponentGroup<Component...>, MonoType *managedType, Entity e)
 		{
+            EG_PROFILE_FUNCTION();
 			CopyComponentValuesToChildren<Component...>(managedType, e);
 		}
 
 		template <typename... Component>
 		void InheritComponent(MonoType *managedType, Entity e, bool isUndo)
 		{
+            EG_PROFILE_FUNCTION();
 			([&managedType, &e, &isUndo]()
 			 {
 					if (std::strcmp(getSubstringAfterColon(typeid(Component).name()), getSubstringAfterDot(mono_type_get_name(managedType))) == 0)
@@ -137,12 +149,14 @@ namespace eg
 		template <typename... Component>
 		void InheritComponent(ComponentGroup<Component...>, MonoType *managedType, Entity e, bool isUndo)
 		{
+            EG_PROFILE_FUNCTION();
 			InheritComponent<Component...>(managedType, e, isUndo);
 		}
 
 		template <typename... Component>
 		void AddComponent(MonoType *managedType, Entity e)
 		{
+            EG_PROFILE_FUNCTION();
 			([&managedType, &e]()
 			 {
 					if (std::strcmp(getSubstringAfterColon(typeid(Component).name()), getSubstringAfterDot(mono_type_get_name(managedType))) == 0)
@@ -153,12 +167,14 @@ namespace eg
 		template <typename... Component>
 		void AddComponent(ComponentGroup<Component...>, MonoType *managedType, Entity e)
 		{
+            EG_PROFILE_FUNCTION();
 			AddComponent<Component...>(managedType, e);
 		}
 
 		template <typename... Component>
 		void RemoveComponent(MonoType *managedType, Entity e)
 		{
+            EG_PROFILE_FUNCTION();
 			([&managedType, &e]()
 			 {
 					if (std::strcmp(getSubstringAfterColon(typeid(Component).name()), getSubstringAfterDot(mono_type_get_name(managedType))) == 0)
@@ -169,6 +185,7 @@ namespace eg
 		template <typename... Component>
 		void RemoveComponent(ComponentGroup<Component...>, MonoType *managedType, Entity e)
 		{
+            EG_PROFILE_FUNCTION();
 			RemoveComponent<Component...>(managedType, e);
 		}
 	}
@@ -183,17 +200,20 @@ namespace eg
 #pragma region Console
 	static void Console_Log(MonoString* message, ConsolePanel::LogType logType)
 	{
+        EG_PROFILE_FUNCTION();
 		ConsolePanel::Log(Utils::MonoStringToString(message), logType);
 	}
 #pragma endregion
 #pragma region Entity
 	static MonoObject* Entity_GetScriptInstance(UUID uuid, MonoString* name)
 	{
+        EG_PROFILE_FUNCTION();
 		return ScriptEngine::GetManagedInstance(uuid, Utils::MonoStringToString(name));
 	}
 
 	static bool Entity_IsInheritedInChildren(UUID uuid, MonoReflectionType *componentType)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity e = scene->GetEntityByUUID(uuid);
@@ -204,6 +224,7 @@ namespace eg
 
 	static bool Entity_IsInheritedFromParent(UUID uuid, MonoReflectionType *componentType)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity e = scene->GetEntityByUUID(uuid);
@@ -214,6 +235,7 @@ namespace eg
 
 	static void Entity_CopyComponentToChildren(UUID uuid, MonoReflectionType *componentType, bool isUndo)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity e = scene->GetEntityByUUID(uuid);
@@ -224,6 +246,7 @@ namespace eg
 
 	static void Entity_CopyComponentValuesToChildren(UUID uuid, MonoReflectionType *componentType)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity e = scene->GetEntityByUUID(uuid);
@@ -234,6 +257,7 @@ namespace eg
 
 	static void Entity_RemoveAnyChildren(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -242,6 +266,7 @@ namespace eg
 
 	static void Entity_RemoveChild(UUID uuid, UUID childUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -251,6 +276,7 @@ namespace eg
 
 	static void Entity_AddChild(UUID uuid, UUID childUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -260,6 +286,7 @@ namespace eg
 
 	static bool Entity_IsChildOfAny(UUID uuid, UUID childUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -269,6 +296,7 @@ namespace eg
 
 	static bool Entity_IsChild(UUID uuid, UUID childUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -278,6 +306,7 @@ namespace eg
 
 	static int64_t Entity_GetParent(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -289,6 +318,7 @@ namespace eg
 
 	static void Entity_SetParent(UUID uuid, UUID parentUUID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -298,6 +328,7 @@ namespace eg
 
 	static void Entity_InheritComponent(UUID uuid, MonoReflectionType *componentType, bool isUndo)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity e = scene->GetEntityByUUID(uuid);
@@ -314,6 +345,7 @@ namespace eg
 
 	static int64_t* Entity_GetAnyChildren(UUID uuid, int* size)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -335,6 +367,7 @@ namespace eg
 
 	static int64_t* Entity_GetChildren(UUID uuid, int* size)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -356,6 +389,7 @@ namespace eg
 
 	static bool Entity_HasComponent(UUID uuid, MonoReflectionType *componentType)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -368,6 +402,7 @@ namespace eg
 
 	static void Entity_AddComponent(UUID uuid, MonoReflectionType *componentType)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity e = scene->GetEntityByUUID(uuid);
@@ -384,6 +419,7 @@ namespace eg
 
 	static void Entity_RemoveComponent(UUID uuid, MonoReflectionType *componentType)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity e = scene->GetEntityByUUID(uuid);
@@ -400,6 +436,7 @@ namespace eg
 
 	static int64_t Entity_FindEntityByName(MonoString *name)
 	{
+        EG_PROFILE_FUNCTION();
 		char *cStr = mono_string_to_utf8(name);
 
 		Scene *scene = ScriptEngine::GetSceneContext();
@@ -415,9 +452,10 @@ namespace eg
 
 	static int64_t* Entity_FindEntitiesByName(MonoString * name, int* size)
         {
+            EG_PROFILE_FUNCTION();
             Scene* scene = ScriptEngine::GetSceneContext();
             EG_CORE_ASSERT(scene, "No scene context!");
-			
+
 			char *cStr = mono_string_to_utf8(name);
 
 			std::vector<Entity> entities;
@@ -436,6 +474,7 @@ namespace eg
 
 	static bool Entity_Exists(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		return scene->EntityExists(uuid);
@@ -443,6 +482,7 @@ namespace eg
 
 	static int64_t Entity_Create(MonoString *name)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity e = scene->CreateEntity(Utils::MonoStringToString(name));
@@ -455,6 +495,7 @@ namespace eg
 
 	static void Entity_Destroy(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity e = scene->GetEntityByUUID(uuid);
@@ -463,6 +504,7 @@ namespace eg
 
 	static MonoString *Entity_GetName(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity e = scene->GetEntityByUUID(uuid);
@@ -471,6 +513,7 @@ namespace eg
 
 	static void Entity_SetName(UUID uuid, MonoString *name)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity e = scene->GetEntityByUUID(uuid);
@@ -482,6 +525,7 @@ namespace eg
 #pragma region Transform
 	static void TransformComponent_GetTranslation(UUID uuid, glm::vec3 *outTranslation)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		*outTranslation = entity.GetComponent<TransformComponent>().Translation;
@@ -489,6 +533,7 @@ namespace eg
 
 	static void TransformComponent_SetTranslation(UUID uuid, glm::vec3 *translation)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<TransformComponent>().Translation = *translation;
@@ -496,6 +541,7 @@ namespace eg
 
 	static void TransformComponent_GetRotation(UUID uuid, glm::vec3 *outRotation)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		*outRotation = entity.GetComponent<TransformComponent>().Rotation;
@@ -503,6 +549,7 @@ namespace eg
 
 	static void TransformComponent_SetRotation(UUID uuid, glm::vec3 *rotation)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<TransformComponent>().Rotation = *rotation;
@@ -510,6 +557,7 @@ namespace eg
 
 	static void TransformComponent_GetScale(UUID uuid, glm::vec3 *outScale)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		*outScale = entity.GetComponent<TransformComponent>().Scale;
@@ -517,6 +565,7 @@ namespace eg
 
 	static void TransformComponent_SetScale(UUID uuid, glm::vec3 *scale)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<TransformComponent>().Scale = *scale;
@@ -527,6 +576,7 @@ namespace eg
 #pragma region SpriteRenderer
 	static void SpriteRendererComponent_GetColor(UUID uuid, glm::vec4 *outColor)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		*outColor = entity.GetComponent<SpriteRendererComponent>().Color;
@@ -534,6 +584,7 @@ namespace eg
 
 	static void SpriteRendererComponent_SetColor(UUID uuid, glm::vec4 *color)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<SpriteRendererComponent>().Color = *color;
@@ -541,6 +592,7 @@ namespace eg
 
 	static float SpriteRendererComponent_GetTilingFactor(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<SpriteRendererComponent>().TilingFactor;
@@ -548,6 +600,7 @@ namespace eg
 
 	static void SpriteRendererComponent_SetTilingFactor(UUID uuid, float tilingFactor)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<SpriteRendererComponent>().TilingFactor = tilingFactor;
@@ -555,6 +608,7 @@ namespace eg
 
 	static MonoString *SpriteRendererComponent_GetTexture(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		Ref<Texture2D> texture = entity.GetComponent<SpriteRendererComponent>().Texture;
@@ -563,6 +617,7 @@ namespace eg
 
 	static void SpriteRendererComponent_SetTexture(UUID uuid, MonoString *texturePath)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<SpriteRendererComponent>().Texture = Texture2D::Create(Utils::MonoStringToString(texturePath));
@@ -572,6 +627,7 @@ namespace eg
 #pragma region CircleRenderer
 	static void CircleRendererComponent_GetColor(UUID uuid, glm::vec4 *outColor)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		*outColor = entity.GetComponent<CircleRendererComponent>().Color;
@@ -579,6 +635,7 @@ namespace eg
 
 	static void CircleRendererComponent_SetColor(UUID uuid, glm::vec4 *color)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CircleRendererComponent>().Color = *color;
@@ -586,6 +643,7 @@ namespace eg
 
 	static float CircleRendererComponent_GetThickness(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<CircleRendererComponent>().Thickness;
@@ -593,6 +651,7 @@ namespace eg
 
 	static void CircleRendererComponent_SetThickness(UUID uuid, float thickness)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CircleRendererComponent>().Thickness = thickness;
@@ -600,6 +659,7 @@ namespace eg
 
 	static float CircleRendererComponent_GetFade(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<CircleRendererComponent>().Fade;
@@ -607,6 +667,7 @@ namespace eg
 
 	static void CircleRendererComponent_SetFade(UUID uuid, float fade)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CircleRendererComponent>().Fade = fade;
@@ -616,6 +677,7 @@ namespace eg
 #pragma region Animator
 	static void AnimatorComponent_PlayAnimation(UUID uuid, MonoString *animationName)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->Play();
@@ -623,6 +685,7 @@ namespace eg
 
 	static void AnimatorComponent_StopAnimation(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->Stop();
@@ -630,6 +693,7 @@ namespace eg
 
 	static void AnimatorComponent_UpdateAnimation(UUID uuid, float dt)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->Update(dt);
@@ -637,6 +701,7 @@ namespace eg
 
 	static void AnimatorComponent_ChangeAnimation(UUID uuid, MonoString *animationName)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->ChangeAnimation(Utils::MonoStringToString(animationName));
@@ -644,6 +709,7 @@ namespace eg
 
 	static void AnimatorComponent_PauseAnimation(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->Pause();
@@ -651,6 +717,7 @@ namespace eg
 
 	static void AnimatorComponent_SetSpeed(UUID uuid, float speed)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->SetSpeed(speed);
@@ -658,6 +725,7 @@ namespace eg
 
 	static float AnimatorComponent_GetSpeed(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<AnimatorComponent>().Animator2D->GetSpeed();
@@ -665,6 +733,7 @@ namespace eg
 
 	static const Ref<Animation> AnimatorComponent_GetCurrentAnimation(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<AnimatorComponent>().Animator2D->GetCurrentAnimation();
@@ -672,6 +741,7 @@ namespace eg
 
 	static void AnimatorComponent_AddAnimation(UUID uuid, MonoString *animationName)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->AddAnimationWithName(Utils::MonoStringToString(animationName));
@@ -679,6 +749,7 @@ namespace eg
 
 	static void AnimatorComponent_RemoveAnimation(UUID uuid, MonoString *animationName)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->RemoveAnimation(Utils::MonoStringToString(animationName));
@@ -686,6 +757,7 @@ namespace eg
 
 	static void AnimatorComponent_RemoveLastAnimation(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->RemoveLastAnimation();
@@ -693,6 +765,7 @@ namespace eg
 
 	static void AnimatorComponent_TransitionByIndex(UUID uuid, int toIndex)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->Transition(toIndex);
@@ -700,6 +773,7 @@ namespace eg
 
 	static void AnimatorComponent_Transition(UUID uuid, MonoString *toName)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->Transition(Utils::MonoStringToString(toName));
@@ -707,6 +781,7 @@ namespace eg
 
 	static void AnimatorComponent_AddTransition(UUID uuid, MonoString *fromName, MonoString *toName)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->AddTransition(Utils::MonoStringToString(fromName), Utils::MonoStringToString(toName));
@@ -714,6 +789,7 @@ namespace eg
 
 	static void AnimatorComponent_AddTransitionByIndex(UUID uuid, int fromIndex, int toIndex)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->AddTransition(fromIndex, toIndex);
@@ -721,6 +797,7 @@ namespace eg
 
 	static void AnimatorComponent_RemoveTransition(UUID uuid, MonoString *fromName, MonoString *toName)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->RemoveTransition(Utils::MonoStringToString(fromName), Utils::MonoStringToString(toName));
@@ -728,6 +805,7 @@ namespace eg
 
 	static void AnimatorComponent_RemoveTransitionByIndex(UUID uuid, int fromIndex, int toIndex)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<AnimatorComponent>().Animator2D->RemoveTransition(fromIndex, toIndex);
@@ -735,6 +813,7 @@ namespace eg
 
 	static bool AnimatorComponent_CanTransition(UUID uuid, MonoString *fromName, MonoString *toName)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<AnimatorComponent>().Animator2D->CanTransition(Utils::MonoStringToString(fromName), Utils::MonoStringToString(toName));
@@ -742,6 +821,7 @@ namespace eg
 
 	static bool AnimatorComponent_CanTransitionByIndex(UUID uuid, int fromIndex, int toIndex)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<AnimatorComponent>().Animator2D->CanTransition(fromIndex, toIndex);
@@ -751,6 +831,7 @@ namespace eg
 #pragma region Camera
 	static bool CameraComponent_IsPrimary(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<CameraComponent>().Primary;
@@ -758,6 +839,7 @@ namespace eg
 
 	static void CameraComponent_SetPrimary(UUID uuid, bool primary)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CameraComponent>().Primary = primary;
@@ -765,6 +847,7 @@ namespace eg
 
 	static bool CameraComponent_IsFixedAspectRatio(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<CameraComponent>().FixedAspectRatio;
@@ -772,6 +855,7 @@ namespace eg
 
 	static void CameraComponent_SetFixedAspectRatio(UUID uuid, bool fixedAspectRatio)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CameraComponent>().FixedAspectRatio = fixedAspectRatio;
@@ -780,6 +864,7 @@ namespace eg
 #pragma region SceneCamera
 	static void CameraComponent_SetOrtograpic(UUID uuid, float size, float nearClip, float farClip)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CameraComponent>().Camera.SetOrthographic(size, nearClip, farClip);
@@ -787,6 +872,7 @@ namespace eg
 
 	static void CameraComponent_SetPerspective(UUID uuid, float verticalFOV, float nearClip, float farClip)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CameraComponent>().Camera.SetPerspective(verticalFOV, nearClip, farClip);
@@ -794,6 +880,7 @@ namespace eg
 
 	static SceneCamera::ProjectionType CameraComponent_GetProjectionType(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<CameraComponent>().Camera.GetProjectionType();
@@ -801,6 +888,7 @@ namespace eg
 
 	static void CameraComponent_SetProjectionType(UUID uuid, SceneCamera::ProjectionType projectionType)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CameraComponent>().Camera.SetProjectionType(projectionType);
@@ -808,6 +896,7 @@ namespace eg
 
 	static float CameraComponent_GetOrthographicSize(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<CameraComponent>().Camera.GetOrthographicSize();
@@ -815,6 +904,7 @@ namespace eg
 
 	static void CameraComponent_SetOrthographicSize(UUID uuid, float orthographicSize)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CameraComponent>().Camera.SetOrthographicSize(orthographicSize);
@@ -822,6 +912,7 @@ namespace eg
 
 	static float CameraComponent_GetOrthographicNearClip(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<CameraComponent>().Camera.GetOrthographicNearClip();
@@ -829,6 +920,7 @@ namespace eg
 
 	static void CameraComponent_SetOrthographicNearClip(UUID uuid, float orthographicNearClip)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CameraComponent>().Camera.SetOrthographicNearClip(orthographicNearClip);
@@ -836,6 +928,7 @@ namespace eg
 
 	static float CameraComponent_GetOrthographicFarClip(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<CameraComponent>().Camera.GetOrthographicFarClip();
@@ -843,6 +936,7 @@ namespace eg
 
 	static void CameraComponent_SetOrthographicFarClip(UUID uuid, float orthographicFarClip)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CameraComponent>().Camera.SetOrthographicFarClip(orthographicFarClip);
@@ -850,6 +944,7 @@ namespace eg
 
 	static float CameraComponent_GetPerspectiveVerticalFOV(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<CameraComponent>().Camera.GetPerspectiveVerticalFOV();
@@ -857,6 +952,7 @@ namespace eg
 
 	static void CameraComponent_SetPerspectiveVerticalFOV(UUID uuid, float perspectiveVerticalFOV)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CameraComponent>().Camera.SetPerspectiveVerticalFOV(perspectiveVerticalFOV);
@@ -864,6 +960,7 @@ namespace eg
 
 	static float CameraComponent_GetPerspectiveNearClip(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<CameraComponent>().Camera.GetPerspectiveNearClip();
@@ -871,6 +968,7 @@ namespace eg
 
 	static void CameraComponent_SetPerspectiveNearClip(UUID uuid, float perspectiveNearClip)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CameraComponent>().Camera.SetPerspectiveNearClip(perspectiveNearClip);
@@ -878,6 +976,7 @@ namespace eg
 
 	static float CameraComponent_GetPerspectiveFarClip(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		return entity.GetComponent<CameraComponent>().Camera.GetPerspectiveFarClip();
@@ -885,6 +984,7 @@ namespace eg
 
 	static void CameraComponent_SetPerspectiveFarClip(UUID uuid, float perspectiveFarClip)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(uuid);
 		entity.GetComponent<CameraComponent>().Camera.SetPerspectiveFarClip(perspectiveFarClip);
@@ -896,6 +996,7 @@ namespace eg
 #pragma region RigidBody2D
 	static void RigidBody2DComponent_AwakeRuntimeBody(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -905,6 +1006,7 @@ namespace eg
 
 	static void RigidBody2DComponent_ApplyLinearImpulse(UUID uuid, glm::vec2 *impulse, glm::vec2 *point, bool wake)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -917,6 +1019,7 @@ namespace eg
 
 	static void RigidBody2DComponent_ApplyLinearImpulseToCenter(UUID uuid, glm::vec2 *impulse, bool wake)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -932,6 +1035,7 @@ namespace eg
 
 	static void RigidBody2DComponent_SetLinearVelocity(UUID uuid, glm::vec2* linearVelocity)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -945,6 +1049,7 @@ namespace eg
 
 	static void RigidBody2DComponent_GetLinearVelocity(UUID entityID, glm::vec2 *outLinearVelocity)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -958,6 +1063,7 @@ namespace eg
 
 	static RigidBody2DComponent::BodyType RigidBody2DComponent_GetType(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -968,6 +1074,7 @@ namespace eg
 
 	static void RigidBody2DComponent_SetType(UUID entityID, RigidBody2DComponent::BodyType bodyType)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -978,6 +1085,7 @@ namespace eg
 
 	static bool RigidBody2DComponent_IsFixedRotation(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -988,6 +1096,7 @@ namespace eg
 
 	static void RigidBody2DComponent_SetFixedRotation(UUID entityID, bool fixedRotation)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -998,6 +1107,7 @@ namespace eg
 
 	static void RigidBody2DComponent_SetGravityMultiplier(UUID entityID, float newMultiplier)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -1008,6 +1118,7 @@ namespace eg
 
 	static float RigidBody2DComponent_GetGravityMultiplier(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -1018,6 +1129,7 @@ namespace eg
 
 	static void RigidBody2DComponent_ApplyForce(UUID uuid, glm::vec2* force, glm::vec2* point, bool wake)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1030,6 +1142,7 @@ namespace eg
 
 	static void RigidBody2DComponent_ApplyForceToCenter(UUID uuid, glm::vec2* force, bool wake)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1042,6 +1155,7 @@ namespace eg
 
 	static void RigidBody2DComponent_ApplyTorque(UUID uuid,float torque, bool wake)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1054,6 +1168,7 @@ namespace eg
 
 	static void RigidBody2DComponent_SetEnabled(UUID uuid, bool enabled)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1066,6 +1181,7 @@ namespace eg
 
 	static bool RigidBody2DComponent_IsEnabled(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1078,6 +1194,7 @@ namespace eg
 
 	static void RigidBody2DComponent_SetSleepingAllowed(UUID uuid, bool allowed)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1090,6 +1207,7 @@ namespace eg
 
 	static bool RigidBody2DComponent_IsSleepingAllowed(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1102,6 +1220,7 @@ namespace eg
 
 	static float RigidBody2DComponent_GetAngularDamping(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1114,6 +1233,7 @@ namespace eg
 
 	static void RigidBody2DComponent_SetAngularDamping(UUID uuid, float angularDamping)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1126,6 +1246,7 @@ namespace eg
 
 	static void RigidBody2DComponent_SetAngularVelocity(UUID uuid, float velocity)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1138,6 +1259,7 @@ namespace eg
 
 	static float RigidBody2DComponent_GetAngularVelocity(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1150,6 +1272,7 @@ namespace eg
 
 	static b2ContactEdge* RigidBody2DComponent_GetContactList(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1162,6 +1285,7 @@ namespace eg
 
 	static b2JointEdge* RigidBody2DComponent_GetJointList(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1174,6 +1298,7 @@ namespace eg
 
 	static float RigidBody2DComponent_GetLinearDamping(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1186,6 +1311,7 @@ namespace eg
 
 	static void RigidBody2DComponent_SetLinearDamping(UUID uuid, float linearDamping)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1198,6 +1324,7 @@ namespace eg
 
 	static b2Vec2 RigidBody2DComponent_GetLocalPoint(UUID uuid, const b2Vec2& worldPoint)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1210,6 +1337,7 @@ namespace eg
 
 	static b2Vec2 RigidBody2DComponent_GetLocalVector(UUID uuid, const b2Vec2& worldVector)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1222,6 +1350,7 @@ namespace eg
 
 	static float RigidBody2DComponent_GetMass(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1234,6 +1363,7 @@ namespace eg
 
 	static void RigidBody2DComponent_GetMassData(UUID uuid, b2MassData* massData)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1246,6 +1376,7 @@ namespace eg
 
 	static void RigidBody2DComponent_SetMassData(UUID uuid, b2MassData* massData )
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1258,6 +1389,7 @@ namespace eg
 
 	static b2Vec2 RigidBody2DComponent_GetPosition(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1270,6 +1402,7 @@ namespace eg
 
 	static b2Transform RigidBody2DComponent_GetTransform(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1282,6 +1415,7 @@ namespace eg
 
 	static void RigidBody2DComponent_SetTransform(UUID uuid, b2Vec2& position, float angle)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1294,6 +1428,7 @@ namespace eg
 
 	static b2BodyUserData RigidBody2DComponent_GetUserData(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1306,6 +1441,7 @@ namespace eg
 
 	static b2Vec2 RigidBody2DComponent_GetWorldPoint(UUID uuid, const b2Vec2& localPoint)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1318,6 +1454,7 @@ namespace eg
 
 	static b2Vec2 RigidBody2DComponent_GetWorldVector(UUID uuid, const b2Vec2& localVector)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1330,6 +1467,7 @@ namespace eg
 
 	static bool RigidBody2DComponent_IsAwake(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1342,6 +1480,7 @@ namespace eg
 
 	static bool RigidBody2DComponent_IsBullet(UUID uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1354,6 +1493,7 @@ namespace eg
 
 	static void RigidBody2DComponent_SetAwake(UUID uuid, bool awake)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1366,6 +1506,7 @@ namespace eg
 
 	static void RigidBody2DComponent_SetBullet(UUID uuid, bool bullet)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene, "No scene context!");
 		Entity entity = scene->GetEntityByUUID(uuid);
@@ -1688,21 +1829,25 @@ namespace eg
 
 	static bool BoxCollider2DComponent_CollidesWithTopEdge(UUID uuid, UUID other)
 	{
+        EG_PROFILE_FUNCTION();
 		return BoxCollider2DComponent_CollidesWithEdge(uuid, other, Side::TOP);
 	}
 
 	static bool BoxCollider2DComponent_CollidesWithBottomEdge(UUID uuid, UUID other)
 	{
+        EG_PROFILE_FUNCTION();
 		return BoxCollider2DComponent_CollidesWithEdge(uuid, other, Side::BOTTOM);
 	}
 
 	static bool BoxCollider2DComponent_CollidesWithLeftEdge(UUID uuid, UUID other)
 	{
+        EG_PROFILE_FUNCTION();
 		return BoxCollider2DComponent_CollidesWithEdge(uuid, other, Side::LEFT);
 	}
 
 	static bool BoxCollider2DComponent_CollidesWithRightEdge(UUID uuid, UUID other)
 	{
+        EG_PROFILE_FUNCTION();
 		return BoxCollider2DComponent_CollidesWithEdge(uuid, other, Side::RIGHT);
 	}
 
@@ -1734,7 +1879,7 @@ namespace eg
 		EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		Entity entityA = scene->GetEntityByUUID(uuid);
-		
+
 		if(!entityA || !entityA.HasComponent<BoxCollider2DComponent>() || !entityA.HasComponent<RigidBody2DComponent>())
 			return false;
 
@@ -1979,7 +2124,7 @@ namespace eg
 		b2Body* bodyA = (b2Body*)rigidBodyA.RuntimeBody;
 
 		EG_CORE_ASSERT(bodyA, "Body A in CircleCollider2DComponent_CollidesWithPoint is null");
-		
+
 		b2PolygonShape pointShape;
 		pointShape.SetAsBox(0.0001f, 0.0001f, b2Vec2(0, 0), 0);
 
@@ -2022,7 +2167,7 @@ namespace eg
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entityA = scene->GetEntityByUUID(uuid);
 		Entity entityB = scene->GetEntityByUUID(other);
-		
+
 		if(!entityA || !entityB || !entityA.HasComponent<CircleCollider2DComponent>() || !entityB.HasComponent<BoxCollider2DComponent>() || !entityA.HasComponent<RigidBody2DComponent>() || !entityB.HasComponent<RigidBody2DComponent>())
 			return false;
 
@@ -2044,21 +2189,25 @@ namespace eg
 
 	static bool CircleCollider2DComponent_CollidesWithTopEdge(UUID uuid, UUID other)
 	{
+        EG_PROFILE_FUNCTION();
 		return CircleCollider2DComponent_CollidesWithEdge(uuid, other, Side::TOP);
 	}
 
 	static bool CircleCollider2DComponent_CollidesWithBottomEdge(UUID uuid, UUID other)
 	{
+        EG_PROFILE_FUNCTION();
 		return CircleCollider2DComponent_CollidesWithEdge(uuid, other, Side::BOTTOM);
 	}
 
 	static bool CircleCollider2DComponent_CollidesWithLeftEdge(UUID uuid, UUID other)
 	{
+        EG_PROFILE_FUNCTION();
 		return CircleCollider2DComponent_CollidesWithEdge(uuid, other, Side::LEFT);
 	}
 
 	static bool CircleCollider2DComponent_CollidesWithRightEdge(UUID uuid, UUID other)
 	{
+        EG_PROFILE_FUNCTION();
 		return CircleCollider2DComponent_CollidesWithEdge(uuid, other, Side::RIGHT);
 	}
 
@@ -2132,12 +2281,13 @@ namespace eg
 		return b2TestOverlap(GetShapeFromCircleCollider2DComponent(colliderA), 0, &edge, 0, bodyA->GetTransform(), transform);
 	}
 
-	
+
 #pragma endregion
 
 #pragma region Text
 	static MonoString *TextComponent_GetText(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -2150,6 +2300,7 @@ namespace eg
 
 	static void TextComponent_SetText(UUID entityID, MonoString *textString)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -2162,6 +2313,7 @@ namespace eg
 
 	static void TextComponent_GetColor(UUID entityID, glm::vec4 *color)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -2174,6 +2326,7 @@ namespace eg
 
 	static void TextComponent_SetColor(UUID entityID, glm::vec4 *color)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -2186,6 +2339,7 @@ namespace eg
 
 	static float TextComponent_GetKerning(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -2198,6 +2352,7 @@ namespace eg
 
 	static void TextComponent_SetKerning(UUID entityID, float kerning)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -2210,6 +2365,7 @@ namespace eg
 
 	static float TextComponent_GetLineSpacing(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -2222,6 +2378,7 @@ namespace eg
 
 	static void TextComponent_SetLineSpacing(UUID entityID, float lineSpacing)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene *scene = ScriptEngine::GetSceneContext();
 		EG_CORE_ASSERT(scene);
 		Entity entity = scene->GetEntityByUUID(entityID);
@@ -2236,6 +2393,7 @@ namespace eg
 #pragma region Audio
 	static std::filesystem::path Audio_GetPath(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		return entity.GetComponent<AudioSourceComponent>().Audio->GetPath();
@@ -2243,6 +2401,7 @@ namespace eg
 
 	static void Audio_SetPath(UUID entityID, std::filesystem::path val)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		entity.GetComponent<AudioSourceComponent>().Audio->SetPath(val);
@@ -2250,6 +2409,7 @@ namespace eg
 
 	static bool Audio_Play(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		return entity.GetComponent<AudioSourceComponent>().Audio->Play();
@@ -2257,6 +2417,7 @@ namespace eg
 
 	static bool* Audio_IsLoopedPtr(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		return entity.GetComponent<AudioSourceComponent>().Audio->IsLoopedPtr();
@@ -2264,6 +2425,7 @@ namespace eg
 
 	static bool Audio_IsLooped(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		return entity.GetComponent<AudioSourceComponent>().Audio->IsLooped();
@@ -2271,6 +2433,7 @@ namespace eg
 
 	static bool* Audio_IsPlayingFromStartPtr(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		return entity.GetComponent<AudioSourceComponent>().Audio->IsPlayingFromStartPtr();
@@ -2278,6 +2441,7 @@ namespace eg
 
 	static bool Audio_IsPlayingFromStart(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		return entity.GetComponent<AudioSourceComponent>().Audio->IsPlayingFromStart();
@@ -2285,6 +2449,7 @@ namespace eg
 
 	static void Audio_SetIsLooped(UUID entityID, bool isLooped)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		entity.GetComponent<AudioSourceComponent>().Audio->SetIsLooped(isLooped);
@@ -2292,6 +2457,7 @@ namespace eg
 
 	static void Audio_SetIsPlayingFromStart(UUID entityID, bool isPlayingFromStart)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		entity.GetComponent<AudioSourceComponent>().Audio->SetIsPlayingFromStart(isPlayingFromStart);
@@ -2299,6 +2465,7 @@ namespace eg
 
 	static std::string Audio_GetFileName(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		return entity.GetComponent<AudioSourceComponent>().Audio->GetFileName();
@@ -2306,6 +2473,7 @@ namespace eg
 
 	static void Audio_LoadCurrentAudio(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		entity.GetComponent<AudioSourceComponent>().Audio->LoadCurrentAudio();
@@ -2313,6 +2481,7 @@ namespace eg
 
 	static void Audio_OpenAudio(UUID entityID, std::string path)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		entity.GetComponent<AudioSourceComponent>().Audio->OpenAudio(path);
@@ -2320,13 +2489,15 @@ namespace eg
 
 	static void Audio_Stop(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		entity.GetComponent<AudioSourceComponent>().Audio->Stop();
 	}
 
-	static float Audio_GetVolume(UUID entityID) 
+	static float Audio_GetVolume(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		return entity.GetComponent<AudioSourceComponent>().Audio->GetVolume();
@@ -2334,6 +2505,7 @@ namespace eg
 
 	static float* Audio_GetVolumePtr(UUID entityID)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		return entity.GetComponent<AudioSourceComponent>().Audio->GetVolumePtr();
@@ -2341,6 +2513,7 @@ namespace eg
 
 	static void Audio_SetVolume(UUID entityID, float newVolume)
 	{
+        EG_PROFILE_FUNCTION();
 		Scene* scene = ScriptEngine::GetSceneContext();
 		Entity entity = scene->GetEntityByUUID(entityID);
 		entity.GetComponent<AudioSourceComponent>().Audio->SetVolume(newVolume);
@@ -2351,66 +2524,79 @@ namespace eg
 #pragma region Input
 	static MonoString* Input_GetClipboardContent()
 	{
+        EG_PROFILE_FUNCTION();
 		return ScriptEngine::CreateString(Input::GetClipboardContent());
 	}
 
 	static void Input_SetClipboardContent(MonoString* content)
 	{
+        EG_PROFILE_FUNCTION();
 		Input::SetClipboardContent(Utils::MonoStringToString(content).data());
 	}
 
 	static MonoString* Input_GetKeyName(KeyCode keycode)
 	{
+        EG_PROFILE_FUNCTION();
 		return ScriptEngine::CreateString(Input::GetKeyName(keycode));
 	}
 
 	static bool Input_IsKeyPressed(KeyCode keycode)
 	{
+        EG_PROFILE_FUNCTION();
 		return Input::IsKeyPressed(keycode);
 	}
 
 	static bool Input_IsKeyReleased(KeyCode keycode)
 	{
+        EG_PROFILE_FUNCTION();
 		return Input::IsKeyReleased(keycode);
 	}
 
 	static bool Input_IsMouseButtonPressed(MouseCode button)
 	{
+        EG_PROFILE_FUNCTION();
 		return Input::IsMouseButtonPressed(button);
 	}
 
 	static bool Input_IsMouseButtonReleased(MouseCode button)
 	{
+        EG_PROFILE_FUNCTION();
 		return Input::IsMouseButtonReleased(button);
 	}
 
 	static bool Input_IsCursorOnWindow()
 	{
+        EG_PROFILE_FUNCTION();
 		return Input::IsCursorOnWindow();
 	}
 
 	static float Input_GetCursorPositonX()
 	{
+        EG_PROFILE_FUNCTION();
 		return Input::GetCursorPositonX();
 	}
 
 	static float Input_GetCursorPositonY()
 	{
+        EG_PROFILE_FUNCTION();
 		return Input::GetCursorPositonY();
 	}
 
 	static void Input_SetCursorMode(int mode)
 	{
+        EG_PROFILE_FUNCTION();
 		Input::SetCursorMode(mode);
 	}
 
 	static void Input_SetStickyKeysEnabled(bool enable)
 	{
+        EG_PROFILE_FUNCTION();
 		Input::SetStickyKeysEnabled(enable);
 	}
 
 	static void Input_SetStickyMouseButtonsEnabled(bool enable)
 	{
+        EG_PROFILE_FUNCTION();
 		Input::SetStickyMouseButtonsEnabled(enable);
 	}
 #pragma endregion
@@ -2423,6 +2609,7 @@ namespace eg
 
 	void ScriptGlue::RegisterFunctions()
 	{
+        EG_PROFILE_FUNCTION();
 		EG_ADD_INTERNAL_CALL(Entity_Exists);
 		EG_ADD_INTERNAL_CALL(Console_Log);
 
@@ -2653,6 +2840,7 @@ namespace eg
 	template <typename... Component>
 	static void RegisterComponent()
 	{
+        EG_PROFILE_FUNCTION();
 		([]()
 		 {
 				std::string_view typeName = typeid(Component).name();
@@ -2673,12 +2861,14 @@ namespace eg
 	template <typename... Component>
 	static void RegisterComponent(ComponentGroup<Component...>)
 	{
+        EG_PROFILE_FUNCTION();
 		s_EntityHasComponentFunctions.clear();
 		RegisterComponent<Component...>();
 	}
 
 	void ScriptGlue::RegisterComponents()
 	{
+        EG_PROFILE_FUNCTION();
 		RegisterComponent(AllComponents{});
 	}
 }

--- a/Engine/src/Engine/Utils/YAMLConversion.cpp
+++ b/Engine/src/Engine/Utils/YAMLConversion.cpp
@@ -6,6 +6,7 @@ namespace YAML
 {
 	Node convert<glm::vec2>::encode(const glm::vec2& rhs)
 	{
+        EG_PROFILE_FUNCTION();
 		Node node;
 		node.push_back(rhs.x);
 		node.push_back(rhs.y);
@@ -15,6 +16,7 @@ namespace YAML
 
 	bool convert<glm::vec2>::decode(const Node& node, glm::vec2& rhs)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!node.IsSequence() || node.size() != 2)
 			return false;
 
@@ -25,6 +27,7 @@ namespace YAML
 
 	Node convert<glm::vec3>::encode(const glm::vec3& rhs)
 	{
+        EG_PROFILE_FUNCTION();
 		Node node;
 		node.push_back(rhs.x);
 		node.push_back(rhs.y);
@@ -35,6 +38,7 @@ namespace YAML
 
 	bool convert<glm::vec3>::decode(const Node& node, glm::vec3& rhs)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!node.IsSequence() || node.size() != 3)
 			return false;
 
@@ -46,6 +50,7 @@ namespace YAML
 
 	Node convert<glm::vec4>::encode(const glm::vec4& rhs)
 	{
+        EG_PROFILE_FUNCTION();
 		Node node;
 		node.push_back(rhs.x);
 		node.push_back(rhs.y);
@@ -57,6 +62,7 @@ namespace YAML
 
 	bool convert<glm::vec4>::decode(const Node& node, glm::vec4& rhs)
 	{
+        EG_PROFILE_FUNCTION();
 		if (!node.IsSequence() || node.size() != 4)
 			return false;
 
@@ -69,6 +75,7 @@ namespace YAML
 
 	Node convert<eg::UUID>::encode(const eg::UUID& uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		Node node;
 		node.push_back((int64_t)uuid);
 		return node;
@@ -76,11 +83,13 @@ namespace YAML
 
 	bool convert<eg::UUID>::decode(const Node& node, eg::UUID& uuid)
 	{
+        EG_PROFILE_FUNCTION();
 		uuid = node.as<int64_t>();
 		return true;
 	}
 	Emitter& operator<<(YAML::Emitter& out, const glm::vec2& v)
 	{
+        EG_PROFILE_FUNCTION();
 		out << YAML::Flow;
 		out << YAML::BeginSeq << v.x << v.y << YAML::EndSeq;
 		return out;
@@ -88,6 +97,7 @@ namespace YAML
 
 	Emitter& operator<<(YAML::Emitter& out, const glm::vec3& v)
 	{
+        EG_PROFILE_FUNCTION();
 		out << YAML::Flow;
 		out << YAML::BeginSeq << v.x << v.y << v.z << YAML::EndSeq;
 		return out;
@@ -95,6 +105,7 @@ namespace YAML
 
 	Emitter& operator<<(YAML::Emitter& out, const glm::vec4& v)
 	{
+        EG_PROFILE_FUNCTION();
 		out << YAML::Flow;
 		out << YAML::BeginSeq << v.x << v.y << v.z << v.w << YAML::EndSeq;
 		return out;


### PR DESCRIPTION
-oldTime variable which is used for fixedUpdate was only set at the creation of EditorLayer and in the FixedUpdate so when user hit play for the first time oldTime was set to creation time of the EditorLayer.  Thus FixedUpdate was called until it caught up to the old time. 
-Also added profiling to functions which didn't have it