### PR TITLE
Fixed crush. +more

### DIFF
--- a/Engine-Editor/src/EditorLayer.cpp
+++ b/Engine-Editor/src/EditorLayer.cpp
@@ -991,11 +991,21 @@ namespace eg
 	{
 		EG_PROFILE_FUNCTION();
 		std::string filepath = FileDialogs::OpenFile("Muniffic Project (*.mnproj)\0*.mnproj\0");
-		if (filepath.empty())
+		std::filesystem::path path = filepath;
+        if (filepath.empty() )
 		{
 			ConsolePanel::Log("File: EditorLayer.cpp - Empty file path", ConsolePanel::LogType::Error);
 			return false;
 		}
+		if (path.extension() != ".mnproj"){
+            ConsolePanel::Log("File: EditorLayer.cpp - Could not load " + path.filename().string() + " - not a project file", ConsolePanel::LogType::Error);
+            return false;
+		}
+		if (path == Project::GetProjectPath()){
+			ConsolePanel::Log("File: EditorLayer.cpp - Project already opened", ConsolePanel::LogType::Warning);
+            return false;
+	    }
+        //CloseProject();
 		OpenProject(filepath);
 		m_RecentProjectSerializer.Serialize(filepath, "recentProjectSerializer.txt");
 		ConsolePanel::Log("File: EditorLayer.cpp - Project opened", ConsolePanel::LogType::Info);
@@ -1005,6 +1015,9 @@ namespace eg
 	void EditorLayer::OpenProject(const std::filesystem::path& path)
 	{
         EG_PROFILE_FUNCTION();
+        bool isLoaded = Project::IsLoaded();
+		//if (isLoaded)
+            //ScriptEngine::Shutdown();
 		if (m_CurrentProject = Project::Load(path))
 		{
 			ScriptEngine::Init();

--- a/Engine/src/Engine/Project/Project.h
+++ b/Engine/src/Engine/Project/Project.h
@@ -59,6 +59,11 @@ namespace eg {
 			
 		}
 
+		inline static const std::filesystem::path GetProjectPath(){
+            EG_CORE_ASSERT(s_ActiveProject, "No active project");
+            return s_ActiveProject->m_ProjectDirectory / (s_ActiveProject->m_Config.Name + ".mnproj");
+        }
+
 		static void SetProjectName(const std::string& newName) {
 			EG_CORE_ASSERT(s_ActiveProject, "No active project");
 			s_ActiveProject->m_Config.Name = newName;
@@ -111,6 +116,9 @@ namespace eg {
 			EG_CORE_ASSERT(s_ActiveProject, "No active project");
 			return s_ActiveProject->m_ProjectDirectory.parent_path();
 		}
+
+		
+		inline static bool IsLoaded() { return s_ActiveProject != nullptr; }
 
 	private:
 		ProjectConfig m_Config;

--- a/Engine/src/Engine/Scripting/ScriptEngine.cpp
+++ b/Engine/src/Engine/Scripting/ScriptEngine.cpp
@@ -19,6 +19,7 @@
 
 namespace eg
 {
+	static bool s_Initialized = false;
 	static const std::array<std::string,5> s_InternallCallFunctions = { "OnUpdate", "OnCreate", ".ctor", "OnCollisionEnter", "OnCollisionExit" };
 	static std::unordered_map<std::string, ScriptFieldType> s_ScriptFieldTypeMap =
 		{
@@ -135,7 +136,8 @@ namespace eg
 	{
         EG_PROFILE_FUNCTION();
 		s_Data = new ScriptEngineData();
-		InitMono();
+        if (!s_Initialized)
+			InitMono();
 		bool status = LoadAssembly("Resources/Scripts/Debug/Muniffic-ScriptCore.dll");
 		if (!status)
 		{
@@ -174,6 +176,8 @@ namespace eg
 		EG_CORE_ASSERT(domain, "Could not initialize Mono");
 
 		s_Data->RootDomain = domain;
+
+		s_Initialized = true;
 	}
 
 	void ScriptEngine::ShutdownMono()


### PR DESCRIPTION
Engine crushed when user tried to open project, when one was already loaded. The crush happened because mono was initialized again and mono can be initialized only once.
-Added a function to Project which returns whole project path
-Added a function to Project which checks if project is loaded